### PR TITLE
🦾Enhancement: Refactor Loading State UI

### DIFF
--- a/client/src/components/BlueLinearProgress/BlueLinearProgress.jsx
+++ b/client/src/components/BlueLinearProgress/BlueLinearProgress.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { withStyles, makeStyles } from '@material-ui/core/styles';
+import LinearProgress from '@material-ui/core/LinearProgress';
+
+const useStyles = makeStyles((theme) => ({
+  progressContainer: {
+    position: 'fixed',
+    top: theme.spacing(10), // Position right under AppBar
+    left: 0,
+    right: 0,
+    zIndex: theme.zIndex.appBar - 1, // Just below AppBar
+    backgroundColor: 'transparent',
+  },
+}));
+
+const BlueLinearProgress = withStyles((theme) => ({
+  root: {
+    height: 3,
+    backgroundColor: '#e3f2fd',
+  },
+  bar: {
+    backgroundColor: '#2196f3',  // Nice blue color
+  },
+}))(LinearProgress);
+
+// Wrapper component that includes the container styles
+const BlueLinearProgressWithContainer = () => {
+  const classes = useStyles();
+  
+  return (
+    <div className={classes.progressContainer}>
+      <BlueLinearProgress />
+    </div>
+  );
+};
+
+export default BlueLinearProgressWithContainer;
+export { BlueLinearProgress }; // Export the base component for cases where you don't need the container 

--- a/client/src/layouts/Scoreboard.jsx
+++ b/client/src/layouts/Scoreboard.jsx
@@ -21,6 +21,7 @@ import Snackbar from 'mui-pro/Snackbar/Snackbar'
 import MainNavBar from '../components/Navbars/MainNavBar'
 import Sidebar from '../mui-pro/Sidebar/Sidebar'
 import withUser from '../hoc/withUser'
+import BlueLinearProgress from '../components/BlueLinearProgress/BlueLinearProgress'
 
 const theme = createTheme({
   palette: {
@@ -44,6 +45,7 @@ function Scoreboard(props) {
   const history = useHistory()
   const dispatch = useDispatch()
   const snackbar = useSelector((state) => state.ui.snackbar)
+  const globalLoading = useSelector((state) => state.ui.globalLoading)
   const [mobileOpen, setMobileOpen] = React.useState(false)
   const [page, setPage] = React.useState('Home')
   // styles
@@ -134,6 +136,9 @@ function Scoreboard(props) {
             dispatch={dispatch}
           />
         </Hidden>
+        {globalLoading && (
+          <BlueLinearProgress />
+        )}
         <main className={classes.content}>
           {getRoute() ? (
             <Switch>

--- a/client/src/store/ui.js
+++ b/client/src/store/ui.js
@@ -27,6 +27,7 @@ export const uiInitialState = {
   selectedPlan: 'personal',
   focusedComment: null,
   sharedComment: null,
+  globalLoading: false,
 }
 
 const uiSlice = createSlice({
@@ -54,6 +55,9 @@ const uiSlice = createSlice({
     SET_SHARED_COMMENT: (state, action) => {
       state.sharedComment = action.payload
     },
+    SET_GLOBAL_LOADING: (state, action) => {
+      state.globalLoading = action.payload
+    },
   },
 })
 
@@ -65,6 +69,7 @@ export const {
   SET_SELECTED_PLAN,
   SET_FOCUSED_COMMENT,
   SET_SHARED_COMMENT,
+  SET_GLOBAL_LOADING,
 } = uiSlice.actions
 
 export default uiSlice.reducer

--- a/client/src/views/SearchPage/index.jsx
+++ b/client/src/views/SearchPage/index.jsx
@@ -16,6 +16,7 @@ import Carousel from '../../components/Carousel/Carousel';
 import PostCard from '../../components/Post/PostCard';
 import Divider from '@material-ui/core/Divider';
 import LatestQuotes from '../../components/Quotes/LatestQuotes';
+import { SET_GLOBAL_LOADING } from '../../store/ui';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -228,6 +229,7 @@ const useStyles = makeStyles((theme) => ({
       color: theme.palette.primary.contrastText,
       borderRadius: '50%',
     },
+  
   },
 }));
 
@@ -307,6 +309,11 @@ export default function SearchPage() {
   })
 
   const { data: featuredData } = useQuery(GET_FEATURED_POSTS)
+
+  // Dispatch global loading state
+  useEffect(() => {
+    dispatch(SET_GLOBAL_LOADING(loading))
+  }, [loading, dispatch])
 
   // Auto-show results for guest mode
   useEffect(() => {
@@ -692,11 +699,6 @@ export default function SearchPage() {
             )}
             
             <Grid item style={{ width: '100%', maxWidth: '800px' }}>
-              {loading && (
-                <div style={{ textAlign: 'center', padding: '2rem' }}>
-                  <Typography>Loading posts...</Typography>
-                </div>
-              )}
               {processedData && (
                 <Carousel
                   navButtonsAlwaysVisible


### PR DESCRIPTION
# Description
Attempting an easy PR as initial contribution!
Lifting loading state/UI to global layout as opposed to SearchPage.

- [ ] Handle "Refreshing results..." also when logged in?

<!-- Describe to the user what this PR does for the codebase -->
"Loading posts..." was content shifting so I replaced with the linear progress...??  **Any feedback/nitpicks welcome!**
<!-- Describe to the developer what this PR does for the codebase -->
Creates and dispatches SET_GLOBAL_LOADING action

https://github.com/user-attachments/assets/a7f88544-b040-48a9-a042-128721db51f8

## Type of Story:
Feature

<!-- Insert the links of Story and the Design of the task / design you have between the parenthesis -->
<!-- Here are the links to our teams projects to find which task / design -->
<!-- https://www.pivotaltracker.com/n/projects/1579587 -->
<!-- v1 Desktop: https://app.zeplin.io/project/59bd197553787598a1892964/dashboard?seid=5f4baef0fc57ce83b5fdcd26 -->
<!-- v1 Mobile: https://app.zeplin.io/project/59bd197553787598a1892964/dashboard?seid=5f4baf8df379028159bc8a83 -->

- [Pivotal Tracker]()
- [Design]()

## Checklist:

<!-- Please check the boxes once you have completed them. You can check them after you make the pull request using Github. For anything that starts with ` -->

<!-- - [ ] Project was validated by `husky` pre-push  -->
- [x] Proper branch name. See guidelines [here](CONTRIBUTING.md)
- [ ] Add tests or `test.todo` that proves code is effective or that the feature works. See how [here](https://app.tettra.co/teams/voxpop/pages/creating-test)
- [ ] Made corresponding changes to the documentation. See how [here](https://app.tettra.co/teams/voxpop/pages/creating-documentation)
- [ ] Include in Storybook
- [x] Perform a self-review of own code
- [ ] Comments on code, especially in hard-to-understand areas

<!-- If chore or bug, comment the checkboxes that do not apply.  -->

<!-- Note this template is subjected to change depending on the teams needs. -->
