### PR TITLE
Add stripe payment button after invite

### DIFF
--- a/client/src/views/SignupPage/SignupPage.jsx
+++ b/client/src/views/SignupPage/SignupPage.jsx
@@ -22,6 +22,16 @@ export default function SignupPage() {
   const classes = useStyles()
 
   React.useEffect(() => {
+    const script = document.createElement('script')
+    script.src = 'https://js.stripe.com/v3/buy-button.js'
+    script.async = true
+    document.body.appendChild(script)
+    return () => {
+      document.body.removeChild(script)
+    }
+  }, [])
+
+  React.useEffect(() => {
     if (!loadingData && !user) history.push('/error')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadingData, user])
@@ -32,6 +42,13 @@ export default function SignupPage() {
     <div className={classes.container}>
       <GridContainer justify="center" style={{ marginRight: 24 }}>
         <SignupForm user={user} token={token} />
+        <div style={{ marginTop: 20 }}>
+          {/* Stripe payment form */}
+          <stripe-buy-button
+            buy-button-id="buy_btn_1RY6bhP3PjIJfZEbu5CpTDjo"
+            publishable-key="pk_live_51RXriSP3PjIJfZEb1tqnEGBOGFZBHREUxqWHeO22GASJ5It6MKfpakOE3oDtL7II20j5idUR6NuXrBlaKXvszY6q00nn8KxROy"
+          />
+        </div>
       </GridContainer>
     </div>
   )


### PR DESCRIPTION
## Summary
- inject Stripe buy button script in Signup flow
- render Stripe buy button under password form

## Testing
- `npm run test:client` *(fails: vitest not found)*
- `npm run test:server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686215ef6490832ca817cd62c6a54dfc