### PR TITLE
Implement guest redirect

### DIFF
--- a/client/src/utils/auth.js
+++ b/client/src/utils/auth.js
@@ -1,0 +1,23 @@
+export function isAuthenticated() {
+  const storedToken = localStorage.getItem('token');
+  if (!storedToken) return false;
+  try {
+    const { exp } = require('jwt-decode')(storedToken);
+    const currentTime = Date.now() / 1000;
+    if (exp && exp < currentTime) return false;
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+export function requireAuth(action) {
+  return () => {
+    if (!isAuthenticated()) {
+      const redirectPath = encodeURIComponent(window.location.pathname);
+      window.location.href = `https://quote.vote/auth/request-access?from=${redirectPath}`;
+      return;
+    }
+    if (typeof action === 'function') action();
+  };
+}

--- a/client/src/utils/useGuestGuard.js
+++ b/client/src/utils/useGuestGuard.js
@@ -1,14 +1,13 @@
 import { useDispatch } from 'react-redux'
-import { useHistory } from 'react-router-dom'
 import { tokenValidator } from 'store/user'
 
 export default function useGuestGuard() {
   const dispatch = useDispatch()
-  const history = useHistory()
 
   return () => {
     if (!tokenValidator(dispatch)) {
-      history.push('/search')
+      const redirectPath = encodeURIComponent(window.location.pathname)
+      window.location.href = `https://quote.vote/auth/request-access?from=${redirectPath}`
       return false
     }
     return true

--- a/client/src/views/RequestAccessPage/RequestAccessPage.jsx
+++ b/client/src/views/RequestAccessPage/RequestAccessPage.jsx
@@ -110,6 +110,14 @@ export default function RequestAccessPage() {
           </Grid>
 
           <Grid item xs={12}>
+            <Typography
+              variant="body1"
+              align="center"
+              style={{ marginBottom: 16 }}
+            >
+              You need an account to contribute. Viewing is public, but posting,
+              voting, and quoting require an invite.
+            </Typography>
             <Input
               disableUnderline
               placeholder="Enter Email"


### PR DESCRIPTION
## Summary
- add auth helper with `isAuthenticated` and `requireAuth`
- redirect guests from protected actions via `useGuestGuard`
- show invite note on request access page

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0330d394832c9c80728aee30c3c6