### PR TITLE
Implement guest redirect

### DIFF
--- a/client/src/components/Activity/ActivityList.jsx
+++ b/client/src/components/Activity/ActivityList.jsx
@@ -17,7 +17,6 @@ import {
 } from '../../graphql/query'
 import { SET_SELECTED_POST } from '../../store/ui'
 import getActivityContent from '../../utils/getActivityContent'
-import { tokenValidator } from 'store/user'
 
 function LoadActivityCard({ width, activity }) {
   const {
@@ -82,14 +81,6 @@ function LoadActivityCard({ width, activity }) {
   const isLiked = bookmarkedBy.includes(currentUser._id)
   const dispatch = useDispatch()
   const handleCardClick = () => {
-    // Check if user is in guest mode (no valid token)
-    if (!tokenValidator(dispatch)) {
-      // Redirect to search page for guest users
-      history.push('/search')
-      return
-    }
-    
-    // For authenticated users, proceed with normal post navigation
     dispatch(SET_SELECTED_POST(postId))
     history.push(url.replace(/\?/g, ''))
   }

--- a/client/src/components/Post/PostCard.jsx
+++ b/client/src/components/Post/PostCard.jsx
@@ -22,7 +22,6 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import ExpandLessIcon from '@material-ui/icons/ExpandLess'
 import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
-import { tokenValidator } from 'store/user'
 import { useState, useMemo } from 'react'
 
 const GET_GROUP = gql`
@@ -333,14 +332,6 @@ function PostCard(props) {
   })
 
   const handleCardClick = () => {
-    // Check if user is in guest mode (no valid token)
-    if (!tokenValidator(dispatch)) {
-      // Redirect to search page for guest users
-      history.push('/search')
-      return
-    }
-
-    // For authenticated users, proceed with normal post navigation
     dispatch(SET_SELECTED_POST(_id))
     history.push(url.replace(/\?/g, ''))
   }

--- a/client/src/components/PrivateRoute.jsx
+++ b/client/src/components/PrivateRoute.jsx
@@ -10,7 +10,9 @@ function PrivateRoute({ component: Component, requiresAuth, ...rest }) {
       {...rest}
       render={(props) => {
         if (requiresAuth && !tokenValidator(dispatch)) {
-          return <Redirect to="/search" />
+          const redirectPath = encodeURIComponent(props.location.pathname)
+          window.location.href = `https://quote.vote/auth/request-access?from=${redirectPath}`
+          return null
         }
         return <Component {...props} />
       }}

--- a/client/src/routes.jsx
+++ b/client/src/routes.jsx
@@ -49,7 +49,6 @@ const routes = [
     icon: ProfileAvatar,
     component: Profile,
     layout: '/',
-    requiresAuth: true,
   },
   {
     path: '/logout',

--- a/client/src/utils/auth.js
+++ b/client/src/utils/auth.js
@@ -1,0 +1,23 @@
+export function isAuthenticated() {
+  const storedToken = localStorage.getItem('token');
+  if (!storedToken) return false;
+  try {
+    const { exp } = require('jwt-decode')(storedToken);
+    const currentTime = Date.now() / 1000;
+    if (exp && exp < currentTime) return false;
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+export function requireAuth(action) {
+  return () => {
+    if (!isAuthenticated()) {
+      const redirectPath = encodeURIComponent(window.location.pathname);
+      window.location.href = `https://quote.vote/auth/request-access?from=${redirectPath}`;
+      return;
+    }
+    if (typeof action === 'function') action();
+  };
+}

--- a/client/src/utils/useGuestGuard.js
+++ b/client/src/utils/useGuestGuard.js
@@ -1,14 +1,13 @@
 import { useDispatch } from 'react-redux'
-import { useHistory } from 'react-router-dom'
 import { tokenValidator } from 'store/user'
 
 export default function useGuestGuard() {
   const dispatch = useDispatch()
-  const history = useHistory()
 
   return () => {
     if (!tokenValidator(dispatch)) {
-      history.push('/search')
+      const redirectPath = encodeURIComponent(window.location.pathname)
+      window.location.href = `https://quote.vote/auth/request-access?from=${redirectPath}`
       return false
     }
     return true

--- a/client/src/views/RequestAccessPage/RequestAccessPage.jsx
+++ b/client/src/views/RequestAccessPage/RequestAccessPage.jsx
@@ -110,6 +110,14 @@ export default function RequestAccessPage() {
           </Grid>
 
           <Grid item xs={12}>
+            <Typography
+              variant="body1"
+              align="center"
+              style={{ marginBottom: 16 }}
+            >
+              You need an account to contribute. Viewing is public, but posting,
+              voting, and quoting require an invite.
+            </Typography>
             <Input
               disableUnderline
               placeholder="Enter Email"


### PR DESCRIPTION
## Summary
- add auth helper with `isAuthenticated` and `requireAuth`
- redirect guests from protected actions via `useGuestGuard`
- show invite note on request access page
- enable guest navigation to posts and profiles

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0330d394832c9c80728aee30c3c6