### PR TITLE
Redirect unauthenticated participation to invite page

### DIFF
--- a/client/src/components/Activity/ActivityList.jsx
+++ b/client/src/components/Activity/ActivityList.jsx
@@ -84,8 +84,8 @@ function LoadActivityCard({ width, activity }) {
   const handleCardClick = () => {
     // Check if user is in guest mode (no valid token)
     if (!tokenValidator(dispatch)) {
-      // Redirect to search page for guest users
-      history.push('/search')
+      // Redirect unauthenticated users to request access page
+      history.push('/auth/request-access')
       return
     }
     

--- a/client/src/components/Notifications/NotificationLists.jsx
+++ b/client/src/components/Notifications/NotificationLists.jsx
@@ -108,8 +108,8 @@ function NotificationLists({ notifications, pageView }) {
     } else {
       // Check if user is in guest mode (no valid token)
       if (!tokenValidator(dispatch)) {
-        // Redirect to search page for guest users
-        history.push('/search')
+        // Redirect unauthenticated users to request access page
+        history.push('/auth/request-access')
         return
       }
       

--- a/client/src/components/Post/PostCard.jsx
+++ b/client/src/components/Post/PostCard.jsx
@@ -335,8 +335,8 @@ function PostCard(props) {
   const handleCardClick = () => {
     // Check if user is in guest mode (no valid token)
     if (!tokenValidator(dispatch)) {
-      // Redirect to search page for guest users
-      history.push('/search')
+      // Redirect unauthenticated users to request access page
+      history.push('/auth/request-access')
       return
     }
 

--- a/client/src/components/PrivateRoute.jsx
+++ b/client/src/components/PrivateRoute.jsx
@@ -10,7 +10,7 @@ function PrivateRoute({ component: Component, requiresAuth, ...rest }) {
       {...rest}
       render={(props) => {
         if (requiresAuth && !tokenValidator(dispatch)) {
-          return <Redirect to="/search" />
+          return <Redirect to="/auth/request-access" />
         }
         return <Component {...props} />
       }}

--- a/client/src/utils/useGuestGuard.js
+++ b/client/src/utils/useGuestGuard.js
@@ -8,7 +8,7 @@ export default function useGuestGuard() {
 
   return () => {
     if (!tokenValidator(dispatch)) {
-      history.push('/search')
+      history.push('/auth/request-access')
       return false
     }
     return true

--- a/client/src/views/PostsPage/index.jsx
+++ b/client/src/views/PostsPage/index.jsx
@@ -24,7 +24,7 @@ export default function PostRouter() {
 
   if (location.pathname === '/post') {
     if (!tokenValidator(dispatch)) {
-      return <Redirect to="/search" />
+      return <Redirect to="/auth/request-access" />
     }
     return <SubmitPost setOpen={setOpen} />
   }


### PR DESCRIPTION
## Summary
- show invite page when guest tries to act
- gate private routes behind invite page
- guard activity/notification/post card interactions
- redirect new post creation to invite request

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a091a19e8832cb32e63197b975856