### PR TITLE
Enforce login redirect for interactions

### DIFF
--- a/client/src/components/Activity/ActivityList.jsx
+++ b/client/src/components/Activity/ActivityList.jsx
@@ -84,8 +84,8 @@ function LoadActivityCard({ width, activity }) {
   const handleCardClick = () => {
     // Check if user is in guest mode (no valid token)
     if (!tokenValidator(dispatch)) {
-      // Redirect to search page for guest users
-      history.push('/search')
+      const from = encodeURIComponent(history.location.pathname + history.location.search)
+      history.push(`/auth/request-access?from=${from}`)
       return
     }
     

--- a/client/src/components/Notifications/NotificationLists.jsx
+++ b/client/src/components/Notifications/NotificationLists.jsx
@@ -108,8 +108,8 @@ function NotificationLists({ notifications, pageView }) {
     } else {
       // Check if user is in guest mode (no valid token)
       if (!tokenValidator(dispatch)) {
-        // Redirect to search page for guest users
-        history.push('/search')
+        const from = encodeURIComponent(history.location.pathname + history.location.search)
+        history.push(`/auth/request-access?from=${from}`)
         return
       }
       

--- a/client/src/components/Post/PostCard.jsx
+++ b/client/src/components/Post/PostCard.jsx
@@ -335,8 +335,8 @@ function PostCard(props) {
   const handleCardClick = () => {
     // Check if user is in guest mode (no valid token)
     if (!tokenValidator(dispatch)) {
-      // Redirect to search page for guest users
-      history.push('/search')
+      const from = encodeURIComponent(history.location.pathname + history.location.search)
+      history.push(`/auth/request-access?from=${from}`)
       return
     }
 

--- a/client/src/components/PrivateRoute.jsx
+++ b/client/src/components/PrivateRoute.jsx
@@ -10,7 +10,8 @@ function PrivateRoute({ component: Component, requiresAuth, ...rest }) {
       {...rest}
       render={(props) => {
         if (requiresAuth && !tokenValidator(dispatch)) {
-          return <Redirect to="/search" />
+          const from = encodeURIComponent(props.location.pathname + props.location.search)
+          return <Redirect to={`/auth/request-access?from=${from}`} />
         }
         return <Component {...props} />
       }}

--- a/client/src/utils/useGuestGuard.js
+++ b/client/src/utils/useGuestGuard.js
@@ -1,14 +1,16 @@
 import { useDispatch } from 'react-redux'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { tokenValidator } from 'store/user'
 
 export default function useGuestGuard() {
   const dispatch = useDispatch()
   const history = useHistory()
+  const location = useLocation()
 
   return () => {
     if (!tokenValidator(dispatch)) {
-      history.push('/search')
+      const from = encodeURIComponent(location.pathname + location.search)
+      history.push(`/auth/request-access?from=${from}`)
       return false
     }
     return true

--- a/client/src/views/PostsPage/index.jsx
+++ b/client/src/views/PostsPage/index.jsx
@@ -24,7 +24,8 @@ export default function PostRouter() {
 
   if (location.pathname === '/post') {
     if (!tokenValidator(dispatch)) {
-      return <Redirect to="/search" />
+      const from = encodeURIComponent(location.pathname + location.search)
+      return <Redirect to={`/auth/request-access?from=${from}`} />
     }
     return <SubmitPost setOpen={setOpen} />
   }

--- a/client/src/views/RequestAccessPage/RequestAccessPage.jsx
+++ b/client/src/views/RequestAccessPage/RequestAccessPage.jsx
@@ -99,20 +99,26 @@ export default function RequestAccessPage() {
               marginBottom: '2rem',
             }}
           >
-            <img
-              src="/assets/quote-vote-white.svg"
-              alt="logo"
-              style={{
-                width: '100%',
-                height: 'auto',
-              }}
-            />
-          </Grid>
+          <img
+            src="/assets/quote-vote-white.svg"
+            alt="logo"
+            style={{
+              width: '100%',
+              height: 'auto',
+            }}
+          />
+        </Grid>
 
-          <Grid item xs={12}>
-            <Input
-              disableUnderline
-              placeholder="Enter Email"
+        <Grid item xs={12}>
+          <Typography className={classes.message} align="center">
+            You need an account to contribute. Viewing is public, but posting, voting, and quoting require an invite.
+          </Typography>
+        </Grid>
+
+        <Grid item xs={12}>
+          <Input
+            disableUnderline
+            placeholder="Enter Email"
               className={classes.input}
               onChange={(event) => setUserDetails(event.target.value)}
             />


### PR DESCRIPTION
## Summary
- gate all interactive actions behind a request-access redirect
- pass the attempted URL in the `from` query param
- show an invite message on the request access page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0cfc4b20832cbd2ab7d11a133c6e