### PR TITLE
Remove links to trending content

### DIFF
--- a/client/src/components/Activity/ActivityEmptyList.jsx
+++ b/client/src/components/Activity/ActivityEmptyList.jsx
@@ -57,16 +57,16 @@ function ActivityEmptyList() {
 
   const history = useHistory()
   const dispatch = useDispatch()
-  const handleGoToTrending = () => {
+  const handleGoToSearch = () => {
     dispatch(SET_SELECTED_PAGE(1))
-    history.push('/TrendingContent')
+    history.push('/search')
   }
   return (
     <GridContainer className={classes.root}>
       <GridItem xs={12}>
         <p className={classes.paragraph}>
           Welcome to Quote Vote. To read some ideas you need to start following people. You can find your friends or you
-          could go to the trending page and follow anyone.
+          could go to the search page and follow anyone.
         </p>
       </GridItem>
       <GridItem xs={12}>
@@ -84,9 +84,9 @@ function ActivityEmptyList() {
             variant="contained"
             color="primary"
             className={classes.buttons}
-            onClick={handleGoToTrending}
+            onClick={handleGoToSearch}
           >
-            GO TO TRENDING
+            GO TO SEARCH
           </Button>
         </MuiThemeProvider>
       </GridItem>

--- a/client/src/components/Post/Post.jsx
+++ b/client/src/components/Post/Post.jsx
@@ -335,6 +335,32 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
   })
 
   const [deletePost] = useMutation(DELETE_POST, {
+    update(cache, { data: { deletePost } }) {
+      cache.modify({
+        fields: {
+          posts(existing = {}, { readField }) {
+            if (!existing.entities) return existing
+            return {
+              ...existing,
+              entities: existing.entities.filter(
+                (postRef) => readField('_id', postRef) !== deletePost._id,
+              ),
+            }
+          },
+          featuredPosts(existing = {}, { readField }) {
+            if (!existing.entities) return existing
+            return {
+              ...existing,
+              entities: existing.entities.filter(
+                (postRef) => readField('_id', postRef) !== deletePost._id,
+              ),
+            }
+          },
+        },
+      })
+      cache.evict({ id: cache.identify({ __typename: 'Post', _id: deletePost._id }) })
+      cache.gc()
+    },
     refetchQueries: [
       {
         query: GET_TOP_POSTS,

--- a/client/src/components/Profile/AvatarIconButtons.jsx
+++ b/client/src/components/Profile/AvatarIconButtons.jsx
@@ -81,7 +81,7 @@ function AvatarIconButton(props) {
       message: 'Avatar has been updated',
       open: true,
     }))
-    history.push('/TrendingContent')
+    history.push('/search')
   }
 
   const groupedAvatarOptions = _.groupBy(avatarOptions, 'name')

--- a/client/src/components/Profile/NoFollowers.jsx
+++ b/client/src/components/Profile/NoFollowers.jsx
@@ -50,7 +50,7 @@ function NoFollowers({ filter }) {
             {
               filter === 'following' ? (
                 <Typography variant="p">
-                  Here you are going to see people that you like their ideas.  You couple fellow people on the trending page or find some friends.
+                  Here you are going to see people that you like their ideas.  You could search for new people to follow or find some friends.
                 </Typography>
               ) : (
                 <Typography variant="p">
@@ -83,7 +83,7 @@ function NoFollowers({ filter }) {
                     Find Friends
                   </Button>
                   <Button variant="contained" color="primary">
-                    Go to Trending
+                    Go to Search
                   </Button>
                 </>
               ) : (


### PR DESCRIPTION
## Summary
- update ActivityEmptyList, NoFollowers to no longer mention trending
- update avatar update redirect to search page
- remove deleted posts from Apollo cache so profile and search lists refresh automatically

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ded49cba4832c8901ed93a2da36f8