### PR TITLE
Implement guest mode redirects

### DIFF
--- a/client/src/components/PostChat/PostChatSend.jsx
+++ b/client/src/components/PostChat/PostChatSend.jsx
@@ -9,6 +9,7 @@ import Paper from '@material-ui/core/Paper'
 import Hidden from '@material-ui/core/Hidden'
 import IconButton from '@material-ui/core/IconButton'
 import Typography from '@material-ui/core/Typography'
+import useGuestGuard from 'utils/useGuestGuard'
 import { SEND_MESSAGE } from '../../graphql/mutations'
 import { GET_ROOM_MESSAGES } from '../../graphql/query'
 
@@ -61,7 +62,10 @@ function PostChatSend(props) {
     }],
   })
 
+  const ensureAuth = useGuestGuard()
+
   const handleSubmit = async () => {
+    if (!ensureAuth()) return
     dispatch(CHAT_SUBMITTING(true))
 
     const message = {

--- a/client/src/utils/useGuestGuard.js
+++ b/client/src/utils/useGuestGuard.js
@@ -1,14 +1,16 @@
 import { useDispatch } from 'react-redux'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { tokenValidator } from 'store/user'
 
 export default function useGuestGuard() {
   const dispatch = useDispatch()
   const history = useHistory()
+  const location = useLocation()
 
   return () => {
     if (!tokenValidator(dispatch)) {
-      history.push('/search')
+      const from = encodeURIComponent(`${location.pathname}${location.search}`)
+      history.push(`/auth/request-access?from=${from}`)
       return false
     }
     return true

--- a/client/src/views/RequestAccessPage/RequestAccessPage.jsx
+++ b/client/src/views/RequestAccessPage/RequestAccessPage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { tokenValidator } from 'store/user'
 import { useDispatch } from 'react-redux'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { useApolloClient, useMutation } from '@apollo/react-hooks'
 import PersonalForm from 'components/RequestAccess/PersonalForm/PersonalForm'
@@ -24,6 +24,10 @@ export default function RequestAccessPage() {
   const classes = useStyles()
   const dispatch = useDispatch()
   const history = useHistory()
+  const location = useLocation()
+
+  const query = new URLSearchParams(location.search)
+  const fromParam = query.get('from')
 
   const [userDetails, setUserDetails] = useState('')
   const [errorMessage, setErrorMessage] = useState()
@@ -108,6 +112,14 @@ export default function RequestAccessPage() {
               }}
             />
           </Grid>
+
+          {fromParam && (
+            <Grid item xs={12}>
+              <Typography style={{ color: 'white', textAlign: 'center' }}>
+                You need an account to contribute. Viewing is public, but posting, voting, and quoting require an invite.
+              </Typography>
+            </Grid>
+          )}
 
           <Grid item xs={12}>
             <Input


### PR DESCRIPTION
## Summary
- update guest guard to redirect unauthenticated users to invite page with `from` path
- block chat messages for guests using the guest guard
- show explanation message on the request access page when redirected

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0af6c778832c91bbaca5d76e40c3