### PR TITLE
Redirect to search after login

### DIFF
--- a/client/src/store/user.js
+++ b/client/src/store/user.js
@@ -100,7 +100,7 @@ export const userLogin = async (username, password, dispatch, history) => {
         loginError: null,
       })
     )
-    history.push(`/Profile/${username}/avatar`)
+    history.push('/search')
   }
 }
 


### PR DESCRIPTION
## Summary
- go to `/search` after a successful login instead of the avatar page

## Testing
- `npm run test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871d074e820832c915cc38c8422900c