### PR TITLE
Require ToS and CoC acceptance on login & signup

### DIFF
--- a/client/src/components/Login/Login.jsx
+++ b/client/src/components/Login/Login.jsx
@@ -13,7 +13,7 @@ import InputAdornment from '@material-ui/core/InputAdornment'
 import FaceIcon from '@material-ui/icons/Face'
 import LockIcon from '@material-ui/icons/Lock'
 
-import { CircularProgress } from '@material-ui/core'
+import { CircularProgress, Checkbox, FormControlLabel } from '@material-ui/core'
 import { useSelector } from 'react-redux'
 import CardBody from '../../mui-pro/Card/CardBody'
 import Card from '../../mui-pro/Card/Card'
@@ -66,8 +66,14 @@ const useStyles = makeStyles((theme) => ({
 function LoginForm({ onSubmit = () => {}, loading, loginError }) {
   const classes = useStyles()
   const {
-    register, handleSubmit, errors, setError,
+    register,
+    handleSubmit,
+    errors,
+    setError,
+    watch,
   } = useForm()
+  const tosAccepted = watch('tos')
+  const cocAccepted = watch('coc')
 
   useEffect(() => {
     if (loginError && loginError.data && loginError.data.message) {
@@ -140,6 +146,52 @@ function LoginForm({ onSubmit = () => {}, loading, loginError }) {
         error={errors.password}
         helperText={errors.password && errors.password.message}
       />
+      <FormControlLabel
+        control={(
+          <Checkbox
+            color="primary"
+            name="tos"
+            inputRef={register({ required: true })}
+          />
+        )}
+        label={(
+          <Typography variant="body2">
+            I agree to the
+            {' '}
+            <Link href="/quote_vote_terms_of_service.md" target="_blank" rel="noopener noreferrer">
+              Terms of Service
+            </Link>
+          </Typography>
+        )}
+      />
+      {errors.tos && (
+        <Typography color="error" variant="caption">
+          Acceptance required
+        </Typography>
+      )}
+      <FormControlLabel
+        control={(
+          <Checkbox
+            color="primary"
+            name="coc"
+            inputRef={register({ required: true })}
+          />
+        )}
+        label={(
+          <Typography variant="body2">
+            I agree to the
+            {' '}
+            <Link href="/quote_vote_code_of_conduct.md" target="_blank" rel="noopener noreferrer">
+              Code of Conduct
+            </Link>
+          </Typography>
+        )}
+      />
+      {errors.coc && (
+        <Typography color="error" variant="caption">
+          Acceptance required
+        </Typography>
+      )}
       <Button
         className={classes.loginButton}
         size="large"
@@ -147,7 +199,7 @@ function LoginForm({ onSubmit = () => {}, loading, loginError }) {
         variant="contained"
         fullWidth
         type="submit"
-        disabled={loading}
+        disabled={loading || !tosAccepted || !cocAccepted}
       >
         <Typography variant="body1">
           Log in

--- a/client/src/components/SignupForm/SignupForm.jsx
+++ b/client/src/components/SignupForm/SignupForm.jsx
@@ -7,8 +7,14 @@ import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
+import Link from '@material-ui/core/Link';
 
-import { CardActions, CircularProgress } from '@material-ui/core';
+import {
+  CardActions,
+  CircularProgress,
+  Checkbox,
+  FormControlLabel,
+} from '@material-ui/core';
 import { useMutation } from '@apollo/react-hooks';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
@@ -62,6 +68,8 @@ function SignupForm({ user, token }) {
 
   // Watch form values to track validity
   const watchedFields = watch(['username', 'password'])
+  const tosAccepted = watch('tos')
+  const cocAccepted = watch('coc')
 
   const onSubmit = async (values) => {
     // Double-check that there are no form errors before proceeding
@@ -190,21 +198,67 @@ function SignupForm({ user, token }) {
                 id="password"
                 type="password"
                 error={errors.password}
-                helperText={errors.password && errors.password.message}
-              />
-            </Grid>
+              helperText={errors.password && errors.password.message}
+            />
           </Grid>
-        </CardBody>
+        </Grid>
+        <FormControlLabel
+          control={(
+            <Checkbox
+              color="primary"
+              name="tos"
+              inputRef={register({ required: true })}
+            />
+          )}
+          label={(
+            <Typography variant="body2">
+              I agree to the
+              {' '}
+              <Link href="/quote_vote_terms_of_service.md" target="_blank" rel="noopener noreferrer">
+                Terms of Service
+              </Link>
+            </Typography>
+          )}
+        />
+        {errors.tos && (
+          <Typography color="error" variant="caption">
+            Acceptance required
+          </Typography>
+        )}
+        <FormControlLabel
+          control={(
+            <Checkbox
+              color="primary"
+              name="coc"
+              inputRef={register({ required: true })}
+            />
+          )}
+          label={(
+            <Typography variant="body2">
+              I agree to the
+              {' '}
+              <Link href="/quote_vote_code_of_conduct.md" target="_blank" rel="noopener noreferrer">
+                Code of Conduct
+              </Link>
+            </Typography>
+          )}
+        />
+        {errors.coc && (
+          <Typography color="error" variant="caption">
+            Acceptance required
+          </Typography>
+        )}
+      </CardBody>
 
-        <CardActions>
-          <Button
-            className={classes.submitButton}
+      <CardActions>
+        <Button
+          className={classes.submitButton}
             color="secondary"
             variant="contained"
             fullWidth
             type="submit"
-            disabled={loading || !isFormValid}
-            size={"small"}
+          disabled={loading || !isFormValid || !tosAccepted || !cocAccepted}
+          size={"small"}
           >
             <Typography variant="body1">
               Submit


### PR DESCRIPTION
## Summary
- add checkbox confirmations for Terms of Service and Code of Conduct in login
- require the same confirmations when completing signup

## Testing
- `npm run test:client` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871e2a6f74c832cb07a94cba54d0d29