### PR TITLE
Add Interactions To Profile Page

### DIFF
--- a/client/src/components/Activity/Activity.jsx
+++ b/client/src/components/Activity/Activity.jsx
@@ -4,6 +4,7 @@ import { useQuery } from '@apollo/react-hooks'
 import { makeStyles } from '@material-ui/core/styles'
 import { useDispatch, useSelector } from 'react-redux'
 import { Grid } from '@material-ui/core'
+import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab'
 import SubHeader from '../SubHeader'
 import ActivityList from './ActivityList'
 import { GET_USER_ACTIVITY } from '../../graphql/query'
@@ -25,6 +26,9 @@ const useStyles = makeStyles((theme) => ({
       maxWidth: '100%',
     },
   },
+  filters: {
+    marginBottom: 10,
+  },
 }))
 
 export default function Activity({ showSubHeader = true, userId = '' }) {
@@ -32,8 +36,7 @@ export default function Activity({ showSubHeader = true, userId = '' }) {
   const classes = useStyles()
   const limit = 15
   const [offset, setOffset] = useState(0)
-  // const conditions = ['POSTED', 'VOTED', 'COMMENTED', 'QUOTED', 'LIKED']
-  const conditions = ['POSTED']
+  const conditions = ['POSTED', 'VOTED', 'COMMENTED', 'QUOTED', 'LIKED']
   const [selectedEvent, setSelectedEvent] = useState(conditions)
   const [dateRangeFilter, setDateRangeFilter] = useState({ startDate: '', endDate: '' })
   const [selectAll, setSelectAll] = useState('ALL')
@@ -55,7 +58,7 @@ export default function Activity({ showSubHeader = true, userId = '' }) {
       setSelectedEvent(conditions)
       dispatch(FILTER_VALUE(conditions))
     } else {
-      const isAllToggled = newActivityEvent.length === 4
+      const isAllToggled = newActivityEvent.length === conditions.length
       setSelectAll(isAllToggled ? ['ALL'] : [])
       setSelectedEvent(newActivityEvent)
       dispatch(FILTER_VALUE(newActivityEvent))
@@ -101,6 +104,26 @@ export default function Activity({ showSubHeader = true, userId = '' }) {
             />
           </Grid>
         )}
+
+        <Grid item xs={12} className={classes.filters}>
+          <ToggleButtonGroup
+            value={selectAll}
+            exclusive
+            onChange={handleSelectAll}
+            size="small"
+          >
+            <ToggleButton value="ALL">ALL</ToggleButton>
+          </ToggleButtonGroup>
+          <ToggleButtonGroup
+            value={selectedEvent}
+            onChange={handleActivityEvent}
+            size="small"
+          >
+            {conditions.map((cond) => (
+              <ToggleButton key={cond} value={cond}>{cond}</ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+        </Grid>
 
         <Grid item xs={12} className={classes.list}>
           <ActivityList

--- a/client/src/components/Profile/ProfileController.jsx
+++ b/client/src/components/Profile/ProfileController.jsx
@@ -8,7 +8,7 @@ import { SET_SELECTED_PAGE } from 'store/ui'
 
 function ProfileController() {
   //  Set state for events and use viewModel props for redux/apollo?
-  const conditions = ['POSTED', 'VOTED', 'COMMENTED', 'QUOTED']
+  const conditions = ['POSTED', 'VOTED', 'COMMENTED', 'QUOTED', 'LIKED']
   const [selectedEvent, setSelectedEvent] = useState(conditions)
   const [selectAll, setSelectAll] = useState('ALL')
   const [offset, setOffset] = useState(1)
@@ -24,7 +24,7 @@ function ProfileController() {
       setSelectAll(['ALL'])
       setSelectedEvent(conditions)
     } else {
-      const isAllToggled = newActivityEvent.length === 4
+      const isAllToggled = newActivityEvent.length === conditions.length
       setSelectAll(isAllToggled ? ['ALL'] : [])
       setSelectedEvent(newActivityEvent)
     }

--- a/client/src/store/filter.js
+++ b/client/src/store/filter.js
@@ -6,7 +6,7 @@ const uiSlice = createSlice({
   initialState: {
     filter: {
       visibility: false,
-      value: ['POSTED'],
+      value: ['POSTED', 'VOTED', 'COMMENTED', 'QUOTED', 'LIKED'],
     },
     date: {
       visibility: false,

--- a/client/src/views/Profile/ProfileView.jsx
+++ b/client/src/views/Profile/ProfileView.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import AppBar from 'components/Navbars/ProfileHeader'
 import LoadingSpinner from 'components/LoadingSpinner'
 import { Link, Typography } from '@material-ui/core'
-import UserPosts from '../../components/UserPosts'
+import Activity from '../../components/Activity/Activity'
 
 const useStyles = makeStyles(({
   root: {
@@ -77,7 +77,7 @@ function ProfileView({
       </div>
 
       <div className={classes.content}>
-        <UserPosts userId={profileUser._id} />
+        <Activity showSubHeader={false} userId={profileUser._id} />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- show user activity in profile again
- include voting, commenting, quoting and likes as filter conditions
- display filter controls above the activity list

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6886c2fd31a8832ca895a17c657971cb