### PR TITLE
Allow guest profile viewing

### DIFF
--- a/client/src/routes.jsx
+++ b/client/src/routes.jsx
@@ -49,7 +49,6 @@ const routes = [
     icon: ProfileAvatar,
     component: Profile,
     layout: '/',
-    requiresAuth: true,
   },
   {
     path: '/logout',

--- a/server/app/data/utils/requireAuth.js
+++ b/server/app/data/utils/requireAuth.js
@@ -15,6 +15,8 @@ const PUBLIC_QUERIES = [
   'messages',
   'actionReactions',
   'messageReactions',
+  'user',
+  'getUserFollowInfo',
   // add more public queries/mutations
 ];
 


### PR DESCRIPTION
## Summary
- expose profile-related queries as public on server
- let `/Profile` route show for guests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b8d40636c832c863b33c22c8ddaa0