### PR TITLE
Add highlighted text quoting for comments

### DIFF
--- a/client/src/views/PostsPage/PostPage.jsx
+++ b/client/src/views/PostsPage/PostPage.jsx
@@ -180,6 +180,12 @@ function PostPage({ postId }) {
         comments.map((comment) => ({
           ...comment,
           __typename: 'Comment',
+          commentQuote:
+            comment.endWordIndex > comment.startWordIndex
+              ? post.text
+                  .substring(comment.startWordIndex, comment.endWordIndex)
+                  .replace(/(\r\n|\n|\r)/gm, '')
+              : null,
         }))
       )
     }


### PR DESCRIPTION
## Summary
- include highlighted text in comment cards by computing `commentQuote`

## Testing
- `npm test --workspace=client` *(fails: vitest not found)*
- `npm run lint:client` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688b93ed02e8832cad2ad1dd7bbcbcd1