### PR TITLE
Fix auth token format bug

### DIFF
--- a/server/app/data/utils/authentication.js
+++ b/server/app/data/utils/authentication.js
@@ -190,6 +190,9 @@ export const authenticate = async (req, res) => {
 };
 
 export const verifyToken = async (authToken) => {
+  if (authToken && authToken.startsWith('Bearer ')) {
+    authToken = authToken.replace(/^Bearer\s+/i, '');
+  }
   const authSecret = process.env.SECRET;
   const jwt = (jsonwebtoken);
   const decodedJwtTokenRequest = jwt.decode(authToken, { complete: true });


### PR DESCRIPTION
## Summary
- revert the previous GraphQL context change
- allow verifying tokens prefixed with `Bearer ` so clients with that format authenticate correctly

## Testing
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_688c48af56a0832c89731d462d36c2ff