### PR TITLE
Fix token parsing

### DIFF
--- a/client/src/config/apollo.js
+++ b/client/src/config/apollo.js
@@ -28,7 +28,7 @@ const authLink = new ApolloLink((operation, forward) => {
     operation.setContext({
       headers: {
         ...operation.getContext().headers,
-        authorization: token,
+        authorization: `Bearer ${token}`,
       },
     })
   }

--- a/server/app/data/resolvers/mutations/post/toggleVoting.js
+++ b/server/app/data/resolvers/mutations/post/toggleVoting.js
@@ -6,6 +6,7 @@ export const toggleVoting = () => {
     logger.info('Function: toggle voting');
     const { postId } = args;
     const { user } = context;
+    console.log('toggleVoting user context:', user);
 
     if (!user) {
       throw new Error('Authentication required');

--- a/server/app/server.js
+++ b/server/app/server.js
@@ -99,8 +99,12 @@ const server = new ApolloServer({
       authToken = connection.context.authorization || connection.context.token || connection.context.authToken;
       isSubscription = true;
       console.log('[SUBSCRIPTION CONNECTION]');
-    } else {
+    } else if (req) {
       authToken = req.headers.authorization || req.headers.token;
+    }
+
+    if (typeof authToken === 'string' && authToken.startsWith('Bearer ')) {
+      authToken = authToken.slice(7);
     }
 
     const isIntrospection = req && req.body.operationName === 'IntrospectionQuery';


### PR DESCRIPTION
## Summary
- use Bearer token format on the client
- handle `Bearer` tokens in server context
- log user context when toggling voting

## Testing
- `npm run test:server`
- `npm run test:client` *(fails: `CACError: Unknown option --env`)*
- `npm run lint` *(fails: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c53dceff0832cb4804285f660f0b2