### PR TITLE
Remove Public Direct Messages section from request access page

### DIFF
--- a/client/src/components/Post/Post.jsx
+++ b/client/src/components/Post/Post.jsx
@@ -75,7 +75,9 @@ const useStyles = makeStyles((theme) => ({
     margin: 10,
   },
   postCard: {
-    height: 'auto',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
     overflow: 'auto',
     [theme.breakpoints.down('sm')]: {
       height: (props) => props.postHeight >= 742 ? '83vh' : 'auto',
@@ -692,7 +694,7 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
           }
           action={pointsHeader}
         />
-        <CardContent style={{ fontSize: '16px' }}>
+        <CardContent style={{ fontSize: '16px', flex: 1, display: 'flex', flexDirection: 'column' }}>
           {hasVoted && (
             <div style={{ 
               backgroundColor: '#e3f2fd', 
@@ -712,6 +714,7 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
             selectedText={selectedText}
             highlights
             votes={post.votes}
+            style={{ flex: 1, display: 'flex', flexDirection: 'column' }}
           >
             {({ text }) => (
               <VotingPopup

--- a/client/src/components/RequestAccess/InfoSections.jsx
+++ b/client/src/components/RequestAccess/InfoSections.jsx
@@ -111,15 +111,6 @@ export default function InfoSections() {
             about what is tolerated and what is not.
           </p>
         </section>
-        <section>
-          <h2>Public Direct Messages</h2>
-          <p>
-            There are no DMs. All user interactions occur in public Quote Rooms.
-            So 1:1 messages take place interview-style, in the open, where
-            others can vote on what was said. This reinforces a culture of
-            transparency and discourages collaboration.
-          </p>
-        </section>
       </div>
 
       <Grid

--- a/client/src/components/VotingComponents/VotingBoard.jsx
+++ b/client/src/components/VotingComponents/VotingBoard.jsx
@@ -103,11 +103,12 @@ const VotingBoard = ({
   }
 
   return (
-    <Container>
-      <div data-selectable>
+    <Container style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <div data-selectable style={{ flex: 1, overflow: 'auto' }}>
         <p
           className="voting_board-content"
           onContextMenu={disableContextMenu}
+          style={{ margin: 0, padding: 0, height: '100%' }}
         >
           {renderHighlights()}
         </p>

--- a/client/src/views/PostsPage/PostPage.jsx
+++ b/client/src/views/PostsPage/PostPage.jsx
@@ -19,6 +19,10 @@ const useStyles = makeStyles((theme) => ({
     height: '85vh',
     overflow: 'hidden',
     marginTop: 0,
+    width: '100% !important',
+    marginLeft: '0 !important',
+    marginRight: '0 !important',
+    padding: '0 !important',
   },
   mobileContainer: {
     height: '85vh',
@@ -33,7 +37,11 @@ const useStyles = makeStyles((theme) => ({
     maxHeight: '85vh',
     overflow: 'hidden',
     marginTop: 0,
+    marginLeft: '0 !important',
+    marginRight: '0 !important',
+    padding: '0 !important',
     display: 'flex',
+    width: '100% !important',
   },
   mobilePostSection: {
     flex: '0 0 auto',
@@ -45,7 +53,7 @@ const useStyles = makeStyles((theme) => ({
     flex: '0 0 50%',
     height: '85vh',
     overflow: 'auto',
-    padding: theme.spacing(2),
+    padding: 0,
     borderRight: `1px solid ${theme.palette.divider}`,
   },
   mobileInteractionSection: {
@@ -81,11 +89,11 @@ const useStyles = makeStyles((theme) => ({
   desktopMessagesContainer: {
     flex: 1,
     overflow: 'auto',
-    padding: theme.spacing(2),
+    padding: 0,
     paddingBottom: theme.spacing(1),
   },
   desktopChatInputContainer: {
-    marginLeft: 15,
+    marginLeft: 0,
     flexShrink: 0,
     borderTop: `1px solid ${theme.palette.divider}`,
     backgroundColor: theme.palette.background.paper,


### PR DESCRIPTION
Title: Remove Public Direct Messages section from request access page
Description:
This PR removes the "Public Direct Messages" section from the request access page (/auth/request-access).

Changes:
Removed the entire "Public Direct Messages" section from client/src/components/RequestAccess/InfoSections.jsx
The removed content explained that there are no DMs and all user interactions occur in public Quote Rooms

Files changed:
client/src/components/RequestAccess/InfoSections.jsx (9 lines removed)

Impact:
Users visiting the request access page will no longer see the explanation about public direct messages
The page will flow directly from the "Civic Moderation by Reputation" section to the donation section