### PR TITLE
🐜 Bug: Password Reset URL Formatting Fix

### DIFF
--- a/server/app/data/resolvers/mutations/user/sendPasswordResetEmail.js
+++ b/server/app/data/resolvers/mutations/user/sendPasswordResetEmail.js
@@ -32,7 +32,7 @@ export const sendPasswordResetEmail = (pubsub) => {
           from: `Team Quote.Vote <${process.env.SENDGRID_SENDER_EMAIL}>`,
           templateId: SENGRID_TEMPLATE_IDS.PASSWORD_RESET,
           dynamicTemplateData: {
-            change_password_url: `${clientUrl}auth/password-reset?token=${token}&username=${username}`,
+            change_password_url: `${clientUrl}/auth/password-reset?token=${token}&username=${username}`,
           },
         };
 

--- a/server/app/server.js
+++ b/server/app/server.js
@@ -22,6 +22,11 @@ if (process.env.NODE_ENV === 'dev') {
   dotenvConfig.config({ path: './.env' });
 }
 
+if (process.env.CLIENT_URL.endsWith('/')) {
+  logger.info('CLIENT_URL ends with /, removing it');
+  process.env.CLIENT_URL = process.env.CLIENT_URL.slice(0, -1);
+}
+
 const GRAPHQL_PORT = process.env.PORT || 3000;
 
 logger.info('Database', process.env.DATABASE_URL);

--- a/server/app/tests/mutations/user/sendPasswordResetEmail.test.js
+++ b/server/app/tests/mutations/user/sendPasswordResetEmail.test.js
@@ -1,0 +1,118 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import UserModel from '~/resolvers/models/UserModel';
+import { sendPasswordResetEmail } from '~/resolvers/mutations/user/sendPasswordResetEmail';
+import * as authenticationUtils from '~/utils/authentication';
+import { logger } from '~/utils/logger';
+import * as sendGridUtils from '~/utils/send-grid-mail';
+
+describe('Mutations > user > sendPasswordResetEmail', () => {
+  let userModelStub;
+  let addCreatorToUserStub;
+  let sendGridEmailStub;
+  let loggerStub;
+  let mockPubsub;
+
+  const mockUser = {
+    _id: 'user123',
+    email: 'test@example.com',
+    username: 'testuser',
+    fullName: 'Test User',
+  };
+
+  const mockToken = 'mock-jwt-token-123';
+
+  beforeEach(() => {
+    process.env.CLIENT_URL = 'https://example.com';
+    process.env.SENDGRID_SENDER_EMAIL = 'noreply@example.com';
+
+    userModelStub = sinon.stub(UserModel, 'findOne');
+    addCreatorToUserStub = sinon.stub(authenticationUtils, 'addCreatorToUser').resolves(mockToken);
+    sendGridEmailStub = sinon.stub(sendGridUtils, 'default').resolves({ success: true });
+    loggerStub = sinon.stub(logger, 'error');
+
+    mockPubsub = {};
+  });
+
+  afterEach(() => {
+    userModelStub.restore();
+    addCreatorToUserStub.restore();
+    sendGridEmailStub.restore();
+    loggerStub.restore();
+  });
+
+  describe('Successful password reset email', () => {
+    it('should send password reset email when user exists', async () => {
+      userModelStub.resolves(mockUser);
+      const args = { email: 'test@example.com' };
+
+      const result = await sendPasswordResetEmail(mockPubsub)(undefined, args);
+
+      expect(result).to.deep.equal(mockUser);
+      
+      sinon.assert.calledOnceWithExactly(userModelStub, { email: 'test@example.com' });
+
+      sinon.assert.calledOnceWithExactly(addCreatorToUserStub, {
+        username: 'testuser',
+        password: '',
+        requirePassword: false,
+      }, sinon.match.func, false, 60 * 60, true);
+
+      sinon.assert.calledOnce(sendGridEmailStub);
+      const emailCall = sendGridEmailStub.getCall(0);
+      const mailOptions = emailCall.args[0];
+      
+      expect(mailOptions).to.deep.include({
+        to: 'test@example.com',
+        from: 'Team Quote.Vote <noreply@example.com>',
+        templateId: sendGridUtils.SENGRID_TEMPLATE_IDS.PASSWORD_RESET,
+      });
+      
+      expect(mailOptions.dynamicTemplateData).to.deep.include({
+        change_password_url: `https://example.com/auth/password-reset?token=${mockToken}&username=testuser`,
+      });
+    });
+
+    it('should handle different email formats correctly', async () => {
+      const userWithDifferentEmail = { ...mockUser, email: 'different@test.com' };
+      userModelStub.resolves(userWithDifferentEmail);
+      const args = { email: 'different@test.com' };
+
+      const result = await sendPasswordResetEmail(mockPubsub)(undefined, args);
+
+      expect(result).to.deep.equal(userWithDifferentEmail);
+      sinon.assert.calledOnceWithExactly(userModelStub, { email: 'different@test.com' });
+    });
+  });
+
+  describe('User not found scenarios', () => {
+    it('should throw wrapped error when email is not found', async () => {
+      userModelStub.resolves(null);
+      const args = { email: 'nonexistent@example.com' };
+
+      try {
+        await sendPasswordResetEmail(mockPubsub)(undefined, args);
+        expect.fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).to.equal('Update failed! Email not found');
+        sinon.assert.calledOnce(loggerStub);
+      }
+
+      sinon.assert.notCalled(addCreatorToUserStub);
+      sinon.assert.notCalled(sendGridEmailStub);
+    });
+
+    it('should throw wrapped error when user is undefined', async () => {
+      userModelStub.resolves(undefined);
+      const args = { email: 'undefined@example.com' };
+
+      try {
+        await sendPasswordResetEmail(mockPubsub)(undefined, args);
+        expect.fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).to.equal('Update failed! Email not found');
+        sinon.assert.calledOnce(loggerStub);
+      }
+    });
+  });
+});


### PR DESCRIPTION
# Description

**User-facing**: This PR improves the password reset functionality by ensuring proper URL formatting in reset emails and adds comprehensive test coverage to prevent regressions in the password reset flow.

**Developer-facing**: This PR fixes a URL formatting issue in password reset emails by adding a trailing slash to the password reset URL, implements automatic cleanup of environment variables that have trailing slashes, and adds a complete test suite for the `sendPasswordResetEmail` function.

## Type of Story:

- [ ] Chore
- [ ] Feature  
- [x] Bug

## Checklist:

<!-- Please check the boxes once you have completed them. You can check them after you make the pull request using Github. For anything that starts with ` -->

<!-- - [ ] Project was validated by `husky` pre-push  -->
- [x] Proper branch name. See guidelines [here](CONTRIBUTING.md)
- [x] Add tests or `test.todo` that proves code is effective or that the feature works. See how [here](https://app.tettra.co/teams/voxpop/pages/creating-test)
- [ ] Made corresponding changes to the documentation. See how [here](https://app.tettra.co/teams/voxpop/pages/creating-documentation)
- [ ] Include in Storybook (N/A - Backend function)
- [x] Perform a self-review of own code
- [ ] Comments on code, especially in hard-to-understand areas

## Changes Made:

### **Files Modified:**

1. **`server/app/data/resolvers/mutations/user/sendPasswordResetEmail.js`**:
   - Fixed password reset URL by adding trailing slash: `${clientUrl}/auth/password-reset`

2. **`server/app/server.js`**:
   - Added automatic cleanup of `CLIENT_URL` environment variable to remove trailing slash, to avoid future issues
   - Added logging for visibility into the cleanup process

### **Files Added:**

3. **`server/app/tests/mutations/user/sendPasswordResetEmail.test.js`**:
   - Validates URL formatting includes trailing slash

## Additional Notes:

This PR also identifies testing infrastructure issues:
- Created issue: https://github.com/QuoteVote/quotevote-monorepo/issues/143

**Testing**: Tests run successfully with individual mocha command but workspace npm scripts have configuration issues that should be addressed separately. 
Test command used from `server` directory: 
```
npx mocha --exit app/tests/mutations/user/sendPasswordResetEmail.test.js --require @babel/register --require @babel/polyfill --check-leaks
``` 