### PR TITLE
fix: make Send button text visible on Forgot Password page (#148)

### DIFF
--- a/client/src/components/ForgotPassword/ForgotPassword.jsx
+++ b/client/src/components/ForgotPassword/ForgotPassword.jsx
@@ -41,8 +41,10 @@ const useStyles = makeStyles({
   },
   sendButton: {
     textTransform: 'none',
-    color: 'white',
-    textColor: 'white',
+    color: '#00bcd4', // Normal state text color
+    '&:hover': {
+      color: '#ffffff', // Hover state text color
+    },
   },
   forgotPassword: {
     textTransform: 'none',
@@ -58,14 +60,9 @@ const useStyles = makeStyles({
   },
 })
 
-function ForgotPasswordForm({
-  onSubmit = () => {
-  }, loading, error,
-}) {
+function ForgotPasswordForm({ onSubmit = () => {}, loading, error }) {
   const classes = useStyles()
-  const {
-    register, handleSubmit, errors, setError,
-  } = useForm()
+  const { register, handleSubmit, errors, setError } = useForm()
 
   useEffect(() => {
     if (error) {
@@ -125,11 +122,7 @@ ForgotPasswordForm.propTypes = {
   error: PropTypes.any,
 }
 
-function ForgotPassword({
-  onSubmit = () => {
-  }, loading = false,
-  error,
-}) {
+function ForgotPassword({ onSubmit = () => {}, loading = false, error }) {
   const classes = useStyles()
   const history = useHistory()
   const handleGoBack = () => {
@@ -150,9 +143,7 @@ function ForgotPassword({
             >
               <ArrowBackIosIcon />
             </IconButton>
-            <span className={classes.header}>
-              Forgot password?
-            </span>
+            <span className={classes.header}>Forgot password?</span>
           </Typography>
           <p className={classes.headerSubText}>
             We will send you a link to reset your password.
@@ -166,7 +157,11 @@ function ForgotPassword({
           spacing={2}
         >
           <Grid item>
-            <ForgotPasswordForm onSubmit={onSubmit} loading={loading} error={error} />
+            <ForgotPasswordForm
+              onSubmit={onSubmit}
+              loading={loading}
+              error={error}
+            />
           </Grid>
           <Grid item>
             <Typography variant="body1">


### PR DESCRIPTION
# Description

This PR fixes a UI issue on the Forgot Password page (`/auth/forgot`) where the **"Send" button text** was invisible in its default state and only became visible on hover.

### What this PR does:
- Sets normal state text color to **#00bcd4**
- Keeps hover state text color **white**
- Ensures the button text is always visible, improving accessibility and UX

### Screenshots:
- Before (text invisible): 
<img width="562" height="513" alt="image" src="https://github.com/user-attachments/assets/d7edda10-bd84-4cd7-a683-639abc1634db" />

- After (text visible, hover white): 
<img width="610" height="623" alt="image" src="https://github.com/user-attachments/assets/bdfd1803-68e7-4765-9fce-48070256b9f9" />


### Type of Story:
- Bug

### Checklist:
- [ ] Proper branch name (`fix/send-button-visibility`)
- [x] Commit message clear and meaningful
- [ ] Screenshots attached
- [ ] Self-reviewed code
