### PR TITLE
docs: add documentation skeleton and structure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,67 @@
+# Quote Vote Documentation
+
+Welcome to the Quote Vote documentation! This is a text-first civic engagement platform for creating posts, voting on specific text passages, and fostering thoughtful discussions.
+
+## 📖 Documentation Structure
+
+This documentation is organized into the following sections:
+
+### 🚀 [Getting Started](./getting-started/)
+
+Everything you need to get Quote Vote running locally and make your first contribution.
+
+- Installation & Setup
+- Prerequisites
+- First Steps
+
+### 🏗️ [Architecture](./architecture/)
+
+Understanding how Quote Vote is built and how the pieces fit together.
+
+- System Overview
+- Backend Architecture (Node.js/GraphQL)
+- Frontend Architecture (React/Apollo)
+- Database Schema (MongoDB)
+
+### 🤝 [Contributing](./contributing/)
+
+Guidelines for contributing to Quote Vote.
+
+- How to Contribute
+- Pull Request Process
+- Code Style Guidelines
+- Testing Standards
+
+### 🚀 [Deployment](./deployment/)
+
+Deploy Quote Vote locally, in production, or for your organization.
+
+- Local Development Setup
+- Production Deployment
+- Self-Hosting Guide
+
+## 🎯 Quick Start
+
+New to Quote Vote? Start here:
+
+1. **[Installation Guide](./getting-started/installation.md)** - Get up and running in 30 minutes
+2. **[Architecture Overview](./architecture/README.md)** - Understand the system
+3. **[Contributing Guide](./contributing/README.md)** - Make your first contribution
+
+## 📚 Additional Resources
+
+- **Project README:** [../README.md](../README.md)
+- **GitHub Issues:** [Link to Issues](https://github.com/QuoteVote/quotevote-monorepo/issues/new/choose)
+- **Live Demo:** [Coming Soon]
+- **Community Discord:** [Coming Soon]
+
+## 🤔 Need Help?
+
+- Check the relevant documentation section
+- Search existing GitHub issues
+- Ask in our community Discord
+- Open a new issue with details
+
+---
+
+**Note:** This documentation is actively being improved! See an issue? Consider contributing - check our [Contributing Guidelines](./contributing/README.md).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,98 @@
+# Quote Vote Architecture
+
+This section explains how Quote Vote is designed and built.
+
+## 📚 Available Documentation
+
+### [Backend Architecture](./backend-architecture.md)
+
+Details about the Node.js/GraphQL backend:
+
+- Server structure
+- GraphQL schema and resolvers
+- Database models (MongoDB/Mongoose)
+- Authentication & authorization
+- Real-time subscriptions
+
+### [Frontend Architecture](./frontend-architecture.md)
+
+Details about the React frontend:
+
+- Component structure
+- Apollo Client setup
+- State management (Redux Toolkit)
+- Routing and layouts
+- Real-time updates
+
+### [Database Schema](./database-schema.md) _(Coming Soon)_
+
+MongoDB collections and data models:
+
+- User model
+- Post model
+- Vote model
+- Comment model
+- Notification model
+
+## 🎯 Quick Overview
+
+**Tech Stack:**
+
+**Frontend:**
+
+- React 17
+- Apollo Client (GraphQL)
+- Material-UI
+- Redux Toolkit
+- Vite
+
+**Backend:**
+
+- Node.js + Express
+- Apollo Server (GraphQL)
+- MongoDB + Mongoose
+- JWT Authentication
+- WebSocket (real-time)
+
+**Key Features:**
+
+- Text-first posts
+- Targeted voting on text passages
+- Quote highlighting system
+- Real-time chat and reactions
+- User profiles and social features
+- Admin moderation tools
+
+## 🏗️ System Overview _(Diagram Coming Soon)_
+
+```
+┌─────────────┐      ┌─────────────┐      ┌─────────────┐
+│   Client    │─────▶│   Server    │─────▶│  Database   │
+│   (React)   │◀─────│  (GraphQL)  │◀─────│  (MongoDB)  │
+└─────────────┘      └─────────────┘      └─────────────┘
+        │                   │
+        │                   │
+        └─────WebSocket─────┘
+         (Real-time Updates)
+```
+
+## 📖 Detailed Documentation
+
+The following documents provide in-depth technical details:
+
+- **[Backend Architecture](./backend-architecture.md)** - Comprehensive backend overview
+- **[Frontend Architecture](./frontend-architecture.md)** - Comprehensive frontend overview
+
+These documents are technical and detailed. If you're new to Quote Vote, start with the Getting Started guide first!
+
+## 🤝 Contributing to Architecture
+
+Found something unclear or outdated? Help us improve:
+
+- [Open an issue](https://github.com/QuoteVote/quotevote-monorepo/issues/new/choose)
+- Submit improvements via PR
+- See [Contributing Guidelines](../contributing/README.md)
+
+---
+
+**Note:** Architecture documentation is being actively improved! Visual diagrams and simplified explanations coming soon - contributions welcome!

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,0 +1,171 @@
+# Contributing to Quote Vote
+
+Thank you for your interest in contributing to Quote Vote! This guide will help you get started.
+
+## 📚 Available Guides
+
+### [Pull Request Process](./pull-request-process.md) _(Coming Soon)_
+
+Step-by-step guide to submitting PRs:
+
+- Fork and branch workflow
+- Commit message conventions
+- PR description guidelines
+- Review process
+
+### [Code Style Guide](./code-style.md) _(Coming Soon)_
+
+Coding standards and conventions:
+
+- JavaScript/TypeScript style
+- React component patterns
+- GraphQL conventions
+- Testing patterns
+
+### [Testing Guide](./testing.md) _(Coming Soon)_
+
+Testing requirements and practices:
+
+- Running tests
+- Writing new tests
+- Coverage expectations
+- E2E testing
+
+## 🚀 Quick Start
+
+**First Time Contributing?**
+
+1. **Find an issue:**
+
+   - Check [issues labeled "good first issue"](https://github.com/QuoteVote/quotevote-monorepo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+   - Check [issues labeled "help wanted"](https://github.com/QuoteVote/quotevote-monorepo/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+   - Check [Hacktoberfest issues](https://github.com/QuoteVote/quotevote-monorepo/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest)
+
+2. **Set up your environment:**
+
+   - Follow the [Getting Started Guide](../getting-started/)
+   - Fork the repository
+   - Create a branch: `git checkout -b feature/your-feature-name`
+
+3. **Make your changes:**
+
+   - Write clear, tested code
+   - Follow the code style guidelines
+   - Update documentation if needed
+
+4. **Submit your PR:**
+   - Push your branch
+   - [Create a Pull Request](https://github.com/QuoteVote/quotevote-monorepo/compare)
+   - Fill out the PR template
+   - Wait for review
+
+## 📋 Contribution Types
+
+We welcome various types of contributions:
+
+- **🐛 Bug Fixes:** Fix issues in the codebase
+- **✨ Features:** Add new functionality
+- **📚 Documentation:** Improve or add documentation
+- **🎨 UI/UX:** Enhance user interface or experience
+- **🧪 Tests:** Add or improve test coverage
+- **♿ Accessibility:** Improve accessibility features
+- **🌐 Translations:** Add language support
+
+## ✅ Before Submitting
+
+Make sure your contribution:
+
+- [ ] Follows the code style guide
+- [ ] Includes tests (if applicable)
+- [ ] Updates documentation (if needed)
+- [ ] Passes all tests: `npm run test`
+- [ ] Passes linting: `npm run lint`
+- [ ] Links to a related issue
+
+## 🤝 Code of Conduct
+
+All contributors are expected to follow our Code of Conduct:
+
+- Be respectful and inclusive
+- Welcome newcomers
+- Focus on constructive feedback
+- Report unacceptable behavior
+
+## 📞 Getting Help
+
+Need help or have questions?
+
+- Comment on the issue you're working on
+- Ask in our Community Discord _(Coming Soon)_
+- Review existing documentation
+- Check similar PRs for examples
+
+## 🎯 Development Workflow
+
+### 1. Fork the Repository
+
+- Go to [https://github.com/QuoteVote/quotevote-monorepo](https://github.com/QuoteVote/quotevote-monorepo).
+- Click **Fork** in the top-right corner.
+
+### 2. Clone Your Fork Locally
+
+Replace `<your-username>` with your GitHub username:
+
+```bash
+git clone https://github.com/<your-username>/quotevote-monorepo.git
+cd quotevote-monorepo
+```
+
+### 3. Create a Branch
+
+```bash
+git checkout -b feature/amazing-feature
+```
+
+### 4. Make Changes
+
+Edit files as needed.
+
+### 5. Test and Lint
+
+```bash
+npm run test
+npm run lint
+```
+
+### 6. Commit Your Changes
+
+```bash
+git add .
+git commit -m "feat: add amazing feature"
+```
+
+### 7. Push to Your Fork
+
+```bash
+git push origin feature/amazing-feature
+```
+
+### 8. Open a Pull Request
+
+- Go to your fork on GitHub and click **Compare & pull request**.
+
+---
+
+### 🏷️ Commit Message Format
+
+Use conventional commits:
+
+- `feat:` New feature
+- `fix:` Bug fix
+- `docs:` Documentation changes
+- `style:` Code style changes (formatting)
+- `refactor:` Code refactoring
+- `test:` Test changes
+- `chore:` Maintenance tasks
+
+**Example:**  
+`feat: add quote highlighting feature`
+
+Thank you for contributing to Quote Vote! 🎉  
+Every contribution, big or small, helps make Quote Vote better for everyone.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,91 @@
+# Deployment Guide
+
+This section covers deploying Quote Vote in various environments.
+
+## 📚 Available Guides
+
+### [Local Development](./local-development.md) _(Coming Soon)_
+
+Detailed local development setup:
+
+- Development environment setup
+- Hot reload configuration
+- Debugging tips
+- Docker setup (optional)
+
+### [Production Deployment](./production.md) _(Coming Soon)_
+
+Deploy to production:
+
+- Build process
+- Environment configuration
+- Platform-specific guides (AWS, GCP, Azure, Vercel)
+- Security considerations
+- Monitoring and logging
+
+### [Self-Hosting Guide](./self-hosting.md) _(Coming Soon)_
+
+For organizations running their own instance:
+
+- Server requirements
+- SSO integration
+- Customization options
+- Data ownership
+- Backup and maintenance
+
+## 🚀 Quick Deploy
+
+### Development (Local)
+
+```bash
+# Install dependencies
+npm run install:all
+
+# Configure environment
+# Copy .env.example to .env in both client/ and server/
+cp client/.env.example client/.env
+cp server/.env.example server/.env
+
+# Start development servers
+npm run dev
+```
+
+Access:
+
+- Frontend: http://localhost:5173
+- Backend: http://localhost:4000
+- GraphQL: http://localhost:4000/graphql
+
+### Production Build
+
+```bash
+# Build both client and server
+npm run build
+
+# Start production server
+npm run start:server
+
+# Frontend: Deploy client/dist/ folder to hosting service
+```
+
+### 🔧 Environment Variables
+
+- Copy `.env.example` to `.env` in both `client/` and `server/` folders.
+- Edit values as needed for your environment.
+
+### 🐳 Docker Support (Coming Soon)
+
+Docker configuration for containerized deployment.
+
+### 📊 Monitoring (Coming Soon)
+
+Production monitoring and logging setup.
+
+### 🔒 Security Considerations (Coming Soon)
+
+Security best practices for production deployments.
+
+---
+
+Need deployment help? Check the detailed guides or ask in our Community Discord.  
+Want to contribute deployment documentation? See our Contributing Guide.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,90 @@
+# Quote Vote: Local Setup and Contribution Guide
+
+This section will help you get Quote Vote running on your local machine and make your first contribution.
+
+## 📚 Guides
+
+### [Installation Guide](./installation.md) _(Coming Soon)_
+
+Step-by-step instructions to:
+
+- Install prerequisites
+- Clone and set up the repository
+- Configure environment variables
+- Start the development servers
+- Verify your installation
+
+### [First Contribution](./first-contribution.md) _(Coming Soon)_
+
+Make your first contribution:
+
+- Finding good first issues
+- Development workflow
+- Submitting your first PR
+
+## 🎯 Quick Start
+
+**Prerequisites:**
+
+- Node.js (version 18 or higher)
+- MongoDB (local or cloud)
+- Git
+
+## 🚀 Setup Steps
+
+### 1. Fork the Repository
+
+- Go to [https://github.com/QuoteVote/quotevote-monorepo](https://github.com/QuoteVote/quotevote-monorepo).
+- Click **Fork** in the top-right corner.
+
+### 2. Clone Your Fork Locally
+
+Replace `<your-username>` with your GitHub username:
+
+```bash
+git clone https://github.com/<your-username>/quotevote-monorepo.git
+cd quotevote-monorepo
+```
+
+### 3. (Optional) Set Up Upstream Remote
+
+```bash
+git remote add upstream https://github.com/QuoteVote/quotevote-monorepo.git
+```
+
+### 4. Install Dependencies
+
+```bash
+npm run install:all
+```
+
+### 5. Copy Environment Variable Templates
+
+Copy `.env.example` files from `client/` and `server/` to `.env` files in the same locations.
+
+### 6. Start Development Servers
+
+```bash
+npm run dev
+```
+
+## 🔗 Access URLs
+
+- **Frontend:** [http://localhost:5173](http://localhost:5173)
+- **GraphQL Playground:** [http://localhost:4000/graphql](http://localhost:4000/graphql)
+
+Refer to the Installation Guide for more details.
+
+## 🤝 Contributing
+
+See the Contributing Guidelines before submitting changes.
+
+## 🛠 Troubleshooting
+
+- **Port conflicts:** Ensure ports 5173 (frontend) and 4000 (backend) are available.
+- **Dependency issues:** Run `npm install --legacy-peer-deps`.
+- **Database connection:** Confirm MongoDB is running.
+
+For more help, check the Installation Guide or ask in Discord.
+
+To suggest improvements, open an issue or submit a pull request.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces a new `/docs` directory at the project root, organizing all documentation into clear subdirectories:  
- `getting-started/` for installation and setup guides  
- `architecture/` for backend/frontend overviews  
- `contributing/` for PR process, code style, and testing standards  
- `deployment/` for local and production setup instructions  
Each subdirectory includes its own `README.md` for navigation and future content.

## Related Issue (Link to issue ticket)

Closes [#175 ](https://github.com/QuoteVote/quotevote-monorepo/issues/175)  

## Motivation and Context

This change improves developer onboarding, centralizes documentation for easier maintenance, and aligns with best practices for open-source projects. It also prepares the project for future wiki migration and makes it easier for new contributors to find relevant guides.

## How Has This Been Tested?

Documentation was reviewed for correct structure, navigation, and link targets. All README links were checked for accuracy in GitHub’s markdown renderer. No code changes were made, so no functional tests were required.

## Screenshots (if appropriate - Postman, etc):

N/A (Documentation only)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. *(N/A for docs)*
- [x] All new and existing tests passed. *(N/A for docs)*

