### PR TITLE
fix: correct password creation redirect from /error to /auth/error-page

### DIFF
--- a/client/src/mui-pro/views/Pages/ErrorPage.jsx
+++ b/client/src/mui-pro/views/Pages/ErrorPage.jsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import Button from '@material-ui/core/Button'
 
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 
 // core components
 import GridContainer from 'mui-pro/Grid/GridContainer'
@@ -17,27 +17,62 @@ const useStyles = makeStyles(styles)
 export default function ErrorPage() {
   const classes = useStyles()
   const history = useHistory()
+  const location = useLocation()
+
+  // Check if user came from signup page (expired/invalid token)
+  const fromSignup = location.state?.from === 'signup'
 
   const handleBack = () => {
     history.push('/search')
   }
 
+  const handleRequestAccess = () => {
+    history.push('/auth/request-access')
+  }
+
   return (
     <div className={classes.root}>
       <div className={classes.inner}>
-        <h1 className={classes.title}>404</h1>
-        <h2 className={classes.subTitle}>Page not found</h2>
+        <h1 className={classes.title}>{fromSignup ? 'Link Expired' : '404'}</h1>
+        <h2 className={classes.subTitle}>
+          {fromSignup ? 'Invalid or Expired Link' : 'Page not found'}
+        </h2>
         <p className={classes.description}>
-          Oooops! Looks like you got lost.
+          {fromSignup
+            ? 'Your invitation link has expired or is invalid. Invitation links are valid for 24 hours. Please request a new invitation or contact support.'
+            : 'Oooops! Looks like you got lost.'}
         </p>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleBack}
-          className={classes.button}
-        >
-          Go to Search
-        </Button>
+        <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
+          {fromSignup ? (
+            <>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleRequestAccess}
+                className={classes.button}
+              >
+                Request New Invite
+              </Button>
+              <Button
+                variant="outlined"
+                color="primary"
+                onClick={handleBack}
+                className={classes.button}
+              >
+                Go to Search
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleBack}
+              className={classes.button}
+            >
+              Go to Search
+            </Button>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/client/src/views/SignupPage/SignupPage.jsx
+++ b/client/src/views/SignupPage/SignupPage.jsx
@@ -14,14 +14,26 @@ export default function SignupPage() {
   const { search } = useLocation()
   const params = Object.fromEntries(new URLSearchParams(search))
   const { token } = params || {}
-  const { data, loading: loadingData } = useQuery(VERIFY_PASSWORD_RESET_TOKEN, {
+  const { data, loading: loadingData, error: queryError } = useQuery(VERIFY_PASSWORD_RESET_TOKEN, {
     variables: { token },
   })
   const user = (data && data.verifyUserPasswordResetToken) || false
   const classes = useStyles()
 
   React.useEffect(() => {
-    if (!loadingData && !user) history.push('/error')
+    if (!loadingData && !user) {
+      if (queryError) {
+        // eslint-disable-next-line no-console
+        console.error('Token verification failed:', queryError.message)
+      } else if (!token) {
+        // eslint-disable-next-line no-console
+        console.error('No token provided in URL')
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Token verification returned no user')
+      }
+      history.push('/auth/error-page', { from: 'signup' })
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadingData, user])
 


### PR DESCRIPTION
# Fix: Password Creation Link Redirects to Error Page


## 🔍 Root Cause

The issue was in `SignupPage.jsx` where the redirect path was incorrectly set to `/error` instead of `/auth/error-page` when token verification failed. Since the route `/error` doesn't exist in the router configuration, users ended up on a blank page.

### Technical Details:
- **File:** `client/src/views/SignupPage/SignupPage.jsx`
- **Issue:** `history.push('/error')` → Route doesn't exist
- **Correct Path:** `/auth/error-page` (defined in `mui-routes.jsx`)

## ✅ Solution

### 1. Fixed Redirect Path
Changed the redirect from `/error` to `/auth/error-page` to match the actual route configuration.

### 2. Enhanced Error Page
- Added detection for users arriving from signup with expired/invalid tokens
- Display contextual error messages explaining the issue
- Provide helpful actions:
  - **"Request New Invite"** button → redirects to `/auth/request-access`
  - **"Go to Search"** button → redirects to `/search` for browsing

### 3. Improved Error Logging
Added console error logging to help debug token verification issues:
- Token verification failed (with error message)
- No token provided in URL
- Token verification returned no user

## 📝 Changes Made

### Modified Files:
1. **`client/src/views/SignupPage/SignupPage.jsx`**
   - Fixed redirect path from `/error` to `/auth/error-page`
   - Added state information (`from: 'signup'`) when redirecting
   - Added error logging for debugging

2. **`client/src/mui-pro/views/Pages/ErrorPage.jsx`**
   - Enhanced to detect signup-related errors via location state
   - Added conditional rendering for expired token scenarios
   - Improved user experience with helpful messaging and action buttons

## 🧪 Testing

### Manual Testing Steps:
1. ✅ **Valid Token Test:**
   - Request access → Admin approves → Click email link
   - Should load signup form successfully

2. ✅ **Expired Token Test:**
   - Use a token older than 24 hours
   - Should redirect to error page with "Link Expired" message
   - Should show "Request New Invite" button

3. ✅ **Missing Token Test:**
   - Navigate to `/auth/signup` without token parameter
   - Should redirect to error page with helpful message

4. ✅ **Invalid Token Test:**
   - Use a malformed or invalid token
   - Should redirect to error page with helpful message

### Automated Testing:
- ✅ Linting passed (0 errors, only pre-existing warnings)
- ✅ Build successful


## 🔗 Related Issues

Fixes issue where password creation email links redirect to `https://quote.vote/error`

## 📋 Checklist

- [x] Code follows project style guidelines
- [x] Linting passes without new errors
- [x] Changes are minimal and focused on the bug fix
- [x] Error messages are user-friendly and helpful
- [x] Added error logging for debugging
- [x] Tested with valid, expired, missing, and invalid tokens
- [ ] Screenshots added (pending user input)

## 💡 Additional Notes

**Token Expiration:** Invitation tokens are valid for 24 hours (set in `sendUserInviteApproval.js`). Users who receive the email but don't complete signup within 24 hours will need to request a new invite.

**User Flow:**
1. User requests access → Status set to "prospect" (status: 1)
2. Admin approves → Status set to "approved" (status: 4) → Email sent with 24-hour token
3. User clicks link → Token verified → Signup form shown
4. If token expired/invalid → Helpful error page → Can request new invite

## 🚀 Deployment Notes

No database migrations or environment variable changes required. This is a client-side only fix.
