### PR TITLE
fix(search): fix @username results and show real profile avatars

### DIFF
--- a/client/src/components/SearchContainer/UsernameResults.jsx
+++ b/client/src/components/SearchContainer/UsernameResults.jsx
@@ -10,7 +10,6 @@ import {
   CircularProgress,
   Box,
 } from '@material-ui/core'
-import PersonIcon from '@material-ui/icons/Person'
 import AvatarDisplay from '../Avatar'
 
 const useStyles = makeStyles((theme) => ({

--- a/client/src/views/SearchPage/index.jsx
+++ b/client/src/views/SearchPage/index.jsx
@@ -12,6 +12,7 @@ import { useSelector } from 'react-redux'
 import { useState, useEffect, useMemo, useRef } from 'react'
 import SearchIcon from '@material-ui/icons/Search'
 import DatePicker from 'react-datepicker'
+import { useHistory } from 'react-router-dom'
 import 'react-datepicker/dist/react-datepicker.css'
 import format from 'date-fns/format'
 import { jwtDecode } from 'jwt-decode'
@@ -318,6 +319,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function SearchPage() {
   const classes = useStyles()
+  const history = useHistory()
   const [showResults, setShowResults] = useState(true)
   const [searchKey, setSearchKey] = useState('')
   const user = useSelector((state) => state.user.data)
@@ -456,7 +458,7 @@ export default function SearchPage() {
       setSelectedUser(null)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resolvedUserData, resolvingUser])
+  }, [resolvedUserData, resolvingUser, shouldResolveUserFromSearch])
 
   // Auto-show results for guest mode and when filters are active
   useEffect(() => {
@@ -1220,48 +1222,61 @@ export default function SearchPage() {
           })() && (
             <>
               {/* Selected/Searched User Header */}
-              {(selectedUser || resolvedUserData?.user) && (
-                <Grid
-                  item
-                  style={{ width: '100%', maxWidth: 600, marginTop: 8 }}
-                >
-                  <Paper
-                    onClick={() =>
-                      (window.location.href = `/Profile/${
-                        (selectedUser || resolvedUserData.user).username
-                      }/`)
-                    }
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 12,
-                      padding: 12,
-                      cursor: 'pointer',
-                      border: '1px solid #e0e0e0',
-                      borderRadius: 8,
-                    }}
-                  >
-                    <div style={{ width: 48, height: 48, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                      <AvatarDisplay height={48} width={48} {...((selectedUser || resolvedUserData.user).avatar || {})} />
-                    </div>
-                    <div style={{ textAlign: 'left' }}>
-                      <Typography
-                        variant="subtitle1"
-                        style={{ lineHeight: 1.1, fontWeight: 600 }}
+              {(selectedUser || resolvedUserData?.user) &&
+                (() => {
+                  const displayUser = selectedUser || resolvedUserData.user
+                  return (
+                    <Grid
+                      item
+                      style={{ width: '100%', maxWidth: 600, marginTop: 8 }}
+                    >
+                      <Paper
+                        onClick={() =>
+                          history.push(`/Profile/${displayUser.username}/`)
+                        }
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 12,
+                          padding: 12,
+                          cursor: 'pointer',
+                          border: '1px solid #e0e0e0',
+                          borderRadius: 8,
+                        }}
                       >
-                        {(selectedUser || resolvedUserData.user).name ||
-                          (selectedUser || resolvedUserData.user).username}
-                      </Typography>
-                      <Typography
-                        variant="body2"
-                        style={{ color: '#666', marginTop: 2 }}
-                      >
-                        @{(selectedUser || resolvedUserData.user).username}
-                      </Typography>
-                    </div>
-                  </Paper>
-                </Grid>
-              )}
+                        <div
+                          style={{
+                            width: 48,
+                            height: 48,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          <AvatarDisplay
+                            height={48}
+                            width={48}
+                            {...(displayUser.avatar || {})}
+                          />
+                        </div>
+                        <div style={{ textAlign: 'left' }}>
+                          <Typography
+                            variant="subtitle1"
+                            style={{ lineHeight: 1.1, fontWeight: 600 }}
+                          >
+                            {displayUser.name || displayUser.username}
+                          </Typography>
+                          <Typography
+                            variant="body2"
+                            style={{ color: '#666', marginTop: 2 }}
+                          >
+                            @{displayUser.username}
+                          </Typography>
+                        </div>
+                      </Paper>
+                    </Grid>
+                  )
+                })()}
 
               {/* Total Count Display */}
               {totalCount > 0 && (


### PR DESCRIPTION
### Summary
Fixes user search to correctly return posts for an existing user when searching with @username, updates search UI to display real user avatars, and adds a clickable user header above results that links to the user’s profile.

### Changes
- Resolve `@username` to `userId` automatically when user submits search without selecting from dropdown.
- Prevent over-filtering by clearing `searchKey` when `userId` is set (so results filter solely by `userId`).
- Add a searched user header at the top of results with avatar, name/username, and link to `/Profile/:username/`.
- Use `AvatarDisplay` for consistent profile avatar rendering in:
  - Search dropdown (username suggestions)
  - Searched user header

### Files Touched
- `client/src/views/SearchPage/index.jsx`
  - Added `GET_USER` query for resolving `@username`
  - Managed `selectedUser`/`selectedUserId` state
  - Cleared `searchKey` when `userId` is active
  - Added user header; uses `AvatarDisplay`
- `client/src/components/SearchContainer/UsernameResults.jsx`
  - Switched avatar to `AvatarDisplay` instead of placeholder/image

### Why
- Previously, submitting `@username` without selecting from the dropdown left `userId` unset and kept `searchKey` as `@username`, causing “No posts found” despite the user existing.
- Avatars in the username dropdown were placeholders, inconsistent with profile avatars.

### UX Impact
- Typing `@username` and pressing Enter now shows that user’s posts.
- Search dropdown and header show consistent avatars matching profile pages.
- Quick access to the full profile via the new header.

### Testing
1. Type `@<existing-username>` and press Enter (without selecting a suggestion):
   - Verify posts list shows that user’s posts.
   - Verify a user header appears above the results; clicking it routes to `/Profile/<username>/`.
2. Type `@<existing-username>` and select from the dropdown:
   - Verify identical behavior as above.
3. Type `@<nonexistent>`:
   - Verify “No users found” in the dropdown and no user header above results.
4. Normal text search (without `@`):
   - Verify results are filtered only by text and no user header is shown.
5. Toggle filters (friends, interactions, date range, sort) to ensure they still work with and without `userId`.

### Edge Cases
- Whitespace around `@username` (e.g., `@user `) is trimmed and still resolves.
- If user resolution fails (unknown username), the user header is not shown and posts aren’t filtered by `userId`.
- Avatars missing profile data still render consistent fallback via `AvatarDisplay`.

### Related Issue
Closes #101 

### Screenshots
- Search dropdown with avatars.
<img width="1900" height="914" alt="ScreenShot Tool -20251116122756" src="https://github.com/user-attachments/assets/17d8f6f3-8c59-4e78-bb98-6ae4644851be" />

- Results list with the user header above posts.
<img width="1885" height="2004" alt="ScreenShot Tool -20251116122842" src="https://github.com/user-attachments/assets/7835c5c5-3d47-490b-a8f0-849e5535cfa4" />
