### PR TITLE
fix: resolve iOS crash when tapping menu button

### DIFF
--- a/client/src/components/Navbars/MainNavBar.jsx
+++ b/client/src/components/Navbars/MainNavBar.jsx
@@ -371,8 +371,9 @@ function MainNavBar(props) {
                 edge="end"
                 aria-label="Open menu"
                 onClick={toggleDrawer}
+                className={classes.iconButton}
               >
-                <MenuIcon style={{ color: classes.iconButton.color }} />
+                <MenuIcon />
               </IconButton>
             </Box>
           </Hidden>

--- a/client/src/components/Notifications/NotificationMenu.jsx
+++ b/client/src/components/Notifications/NotificationMenu.jsx
@@ -114,27 +114,17 @@ function NotificationMenu({ fontSize }) {
             color="error"
             badgeContent={notifications.length}
             overlap="rectangular"
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
           >
             <IconButton
               aria-label="Notifications"
               color="inherit"
               onClick={handleToggle}
             >
-              {isHovered ? (
-                <img 
-                  src="/assets/NotificationsActive.svg" 
-                  alt="notifications active" 
-                  style={{width: fontSize === 'large' ? '49px' : '32px', height: fontSize === 'large' ? '46px' : '30px'}} 
-                />
-              ) : (
-                <img 
-                  src="/assets/Notifications.svg" 
-                  alt="notifications" 
-                  style={{fontSize: fontSize, width: fontSize === 'large' ? '49px' : '32px', height: fontSize === 'large' ? '46px' : '30px'}} 
-                />
-              )}
+              <img 
+                src="/assets/Notifications.svg" 
+                alt="notifications" 
+                style={{width: fontSize === 'large' ? '49px' : '32px', height: fontSize === 'large' ? '46px' : '30px'}} 
+              />
             </IconButton>
           </StyledBadge>
           <MobileDrawer

--- a/client/src/components/Settings/SettingsMenu.jsx
+++ b/client/src/components/Settings/SettingsMenu.jsx
@@ -106,13 +106,11 @@ function SettingsMenu({ fontSize }) {
             aria-label="Settings"
             color="inherit"
             onClick={handleToggle}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
           >
             <SvgIcon
-              component={svgIcon}
+              component={SettingsSvg}
               fontSize={fontSize}
-              viewBox={viewBox}
+              viewBox="0 0 49 46"
             />
           </IconButton>
           <MobileDrawer


### PR DESCRIPTION
## Fix: iOS Menu Crash on Mobile Devices

### Problem
Tapping the menu on iOS Chrome and Safari caused a blank screen crash, blocking access to account settings, invite approvals, and logout.

### Root Causes
1. **MainNavBar.jsx**: Accessing `classes.iconButton.color` when `classes.iconButton` is a string, not an object, causing an undefined property error.
2. **SettingsMenu & NotificationMenu**: Mouse event handlers (`onMouseEnter`/`onMouseLeave`) on mobile components caused touch event conflicts on iOS.

### Solution
- Fixed MenuIcon styling by using `className` instead of inline style with undefined property
- Removed mouse event handlers from mobile versions of SettingsMenu and NotificationMenu
- Simplified mobile icon rendering to use static icons instead of hover states

### Files Changed
- `client/src/components/Navbars/MainNavBar.jsx`
- `client/src/components/Settings/SettingsMenu.jsx`
- `client/src/components/Notifications/NotificationMenu.jsx`

### Related Issue
Closes #281 