### PR TITLE
chore: update MongoDB version to 8.0.17

### DIFF
--- a/server/dev_db/db.Dockerfile
+++ b/server/dev_db/db.Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:8.0.10
+FROM mongo:8.0.17
 # NOTE: Above should be parity with prod mongo version, change if necessary
 
 EXPOSE 27017


### PR DESCRIPTION



## Description

This pull request updates the base image for the MongoDB service in the `db.Dockerfile` from `mongo:8.0.10` to `mongo:8.0.17`to patch MongoBleed vulnerabilities

## Related Issue (Link to issue ticket)

This change addresses a security concern and does not have a corresponding issue ticket.

## Motivation and Context

This change is required to patch the "MongoBleed" vulnerability (CVE-2025-14847), a critical security flaw that affects MongoDB version `8.0.10`. Updating to the patched version `8.0.17` mitigates this security risk for the local development environment.

## How Has This Been Tested?

This change has been tested locally by performing the following steps:

1.  The Docker image for the `mongo` service was successfully rebuilt using the `docker-compose build` command.
2.  The `quotevote-mongo` and `mongo-express` containers were successfully started using the new, secure image with `docker-compose up`.
3.  The `quotevote-next` backend server was confirmed to successfully connect to the database running in the new container.

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
