### PR TITLE
feat(voting): add anonymous voting with display controls

### DIFF
--- a/client/src/components/Navbars/MainNavBar.jsx
+++ b/client/src/components/Navbars/MainNavBar.jsx
@@ -7,6 +7,8 @@ import Toolbar from '@material-ui/core/Toolbar'
 import Button from '@material-ui/core/Button'
 import IconButton from '@material-ui/core/IconButton'
 import Drawer from '@material-ui/core/Drawer'
+import Switch from '@material-ui/core/Switch'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import Divider from '@material-ui/core/Divider'
@@ -27,7 +29,7 @@ import SettingsMenu from '../Settings/SettingsMenu'
 import SubmitPost from '../SubmitPost/SubmitPost'
 import ChatMenu from '../Chat/ChatMenu'
 import AdminIconButton from '../CustomButtons/AdminIconButton'
-import { SET_SELECTED_PAGE } from 'store/ui'
+import { SET_SELECTED_PAGE, SET_SHOW_ANONYMOUS_VOTES } from 'store/ui'
 import { useMobileDetection } from '../../utils/display'
 
 const useStyles = makeStyles((theme) => ({
@@ -216,6 +218,16 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
     padding: theme.spacing(1, 0),
   },
+  voteToggle: {
+    marginLeft: theme.spacing(1),
+    '& .MuiFormControlLabel-label': {
+      fontSize: '0.85rem',
+      fontWeight: 600,
+    },
+  },
+  drawerToggleRow: {
+    padding: theme.spacing(0.5, 0),
+  },
 }))
 
 function MainNavBar(props) {
@@ -223,6 +235,7 @@ function MainNavBar(props) {
   const avatar = useSelector((state) => state.user.data.avatar)
   const name = useSelector((state) => state.user.data.name)
   const loggedIn = useSelector((state) => !!state.user.data._id)
+  const showAnonymousVotes = useSelector((state) => state.ui.showAnonymousVotes)
   const [open, setOpen] = React.useState(false)
   const [drawerOpen, setDrawerOpen] = React.useState(false)
   const dispatch = useDispatch()
@@ -247,6 +260,9 @@ function MainNavBar(props) {
 
   const toggleDrawer = () => setDrawerOpen((prev) => !prev)
   const closeDrawer = () => setDrawerOpen(false)
+  const handleAnonymousVoteToggle = (event) => {
+    dispatch(SET_SHOW_ANONYMOUS_VOTES(event.target.checked))
+  }
 
   return (
     <>
@@ -334,6 +350,18 @@ function MainNavBar(props) {
                 >
                   <GitHubIcon />
                 </IconButton>
+                <FormControlLabel
+                  className={classes.voteToggle}
+                  control={(
+                    <Switch
+                      checked={showAnonymousVotes}
+                      onChange={handleAnonymousVoteToggle}
+                      color="primary"
+                      size="small"
+                    />
+                  )}
+                  label="Show anonymous votes"
+                />
                 <NavLink to="/Profile" style={{ textDecoration: 'none' }}>
                   <Button className={classes.profileButton} onClick={handleProfileClick}>
                     <Avatar>
@@ -479,6 +507,23 @@ function MainNavBar(props) {
             </ListItem>
 
             <Divider className={classes.divider} />
+
+            <ListItem disableGutters>
+              <div className={classes.drawerToggleRow}>
+                <FormControlLabel
+                  className={classes.voteToggle}
+                  control={(
+                    <Switch
+                      checked={showAnonymousVotes}
+                      onChange={handleAnonymousVoteToggle}
+                      color="primary"
+                      size="small"
+                    />
+                  )}
+                  label="Show anonymous votes"
+                />
+              </div>
+            </ListItem>
 
             <ListItem disableGutters>
               <NavLink to="/Profile" style={{ width: '100%', textDecoration: 'none' }}>

--- a/client/src/components/Post/Post.jsx
+++ b/client/src/components/Post/Post.jsx
@@ -32,6 +32,7 @@ import {
   ADD_QUOTE,
   REPORT_POST,
   VOTE,
+  ADD_ANONYMOUS_VOTE,
   APPROVE_POST,
   REJECT_POST,
   DELETE_POST,
@@ -51,6 +52,7 @@ import {
 import AvatarDisplay from '../Avatar'
 import buttonStyle from '../../assets/jss/material-dashboard-pro-react/components/buttonStyle'
 import { serializeVotedBy } from '../../utils/objectIdSerializer'
+import { getVisibleVotes } from '../../utils/votes'
 
 const useStyles = makeStyles((theme) => ({
   header2: {
@@ -222,6 +224,7 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
   const dispatch = useDispatch()
   const history = useHistory()
   const parsedCreated = moment(created).format('LLL')
+  const showAnonymousVotes = useSelector((state) => state.ui.showAnonymousVotes)
 
   // Helper to extract domain from URL
   const getDomain = (url) => {
@@ -241,6 +244,7 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
   })
   const [open, setOpen] = useState(false)
   const [openInvite, setOpenInvite] = useState(false)
+  const [anonymousVoteSubmitted, setAnonymousVoteSubmitted] = useState(false)
 
   const isFollowing = includes(_followingId, userId)
 
@@ -397,6 +401,18 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
       },
     ],
   })
+  const [addAnonymousVote] = useMutation(ADD_ANONYMOUS_VOTE, {
+    refetchQueries: [
+      {
+        query: GET_TOP_POSTS,
+        variables: { limit: 5, offset: 0, searchKey: '' },
+      },
+      {
+        query: GET_POST,
+        variables: { postId: _id },
+      },
+    ],
+  })
   const [addComment] = useMutation(ADD_COMMENT, {
     refetchQueries: [
       {
@@ -489,6 +505,23 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
     )
     return userVote ? userVote.type : null
   }
+
+  const promptCreateAccountToPostOrComment = useCallback(() => {
+    dispatch(
+      SET_SNACKBAR({
+        open: true,
+        message: 'Create an account to post or comment.',
+        type: 'warning',
+      }),
+    )
+    setOpenInvite(true)
+  }, [dispatch])
+
+  const visibleVotes = getVisibleVotes(
+    post.votes || [],
+    post.anonymousVotes || [],
+    showAnonymousVotes,
+  )
 
   const [removeApprove] = useMutation(APPROVE_POST, {
     variables: { postId: _id, userId: user._id },
@@ -657,7 +690,10 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
   }
 
   const handleAddComment = async (comment, commentWithQuote = false) => {
-    if (!ensureAuth()) return
+    if (!ensureAuth()) {
+      promptCreateAccountToPostOrComment()
+      return
+    }
     let startIndex
     let endIndex
     let quoteText
@@ -702,9 +738,10 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
     }
   }
   const handleVoting = async (obj) => {
-    if (!ensureAuth()) return
-    // Check if user has already voted
-    if (hasVoted) {
+    const isAuthenticated = tokenValidator(dispatch)
+    const alreadyVoted = isAuthenticated ? hasVoted : anonymousVoteSubmitted
+
+    if (alreadyVoted) {
       dispatch(
         SET_SNACKBAR({
           open: true,
@@ -718,14 +755,25 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
     const vote = {
       content: selectedText.text || '',
       postId: post._id,
-      userId: user._id,
       type: obj.type,
       tags: obj.tags,
       startWordIndex: selectedText.startIndex,
       endWordIndex: selectedText.endIndex,
     }
     try {
-      await addVote({ variables: { vote } })
+      if (isAuthenticated) {
+        await addVote({
+          variables: {
+            vote: {
+              ...vote,
+              userId: user._id,
+            },
+          },
+        })
+      } else {
+        await addAnonymousVote({ variables: { vote } })
+        setAnonymousVoteSubmitted(true)
+      }
       dispatch(
         SET_SNACKBAR({
           open: true,
@@ -1049,7 +1097,7 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
             flexDirection: 'column',
           }}
         >
-          {hasVoted && (
+          {(hasVoted || anonymousVoteSubmitted) && (
             <div
               style={{
                 backgroundColor: '#e3f2fd',
@@ -1062,7 +1110,7 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
               }}
             >
               ✓ You have already{' '}
-              {getUserVoteType() === 'up' ? 'upvoted' : 'downvoted'} this post
+              {getUserVoteType() === 'up' ? 'upvoted' : getUserVoteType() === 'down' ? 'downvoted' : 'voted on'} this post
             </div>
           )}
           <VotingBoard
@@ -1070,7 +1118,7 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
             onSelect={setSelectedText}
             selectedText={selectedText}
             highlights
-            votes={post.votes}
+            votes={visibleVotes}
             style={{ flex: 1, display: 'flex', flexDirection: 'column' }}
           >
             {({ text }) => (
@@ -1081,7 +1129,7 @@ function Post({ post, user, postHeight, postActions, refetchPost }) {
                 text={text}
                 selectedText={selectedText}
                 votedBy={serializeVotedBy(post.votedBy)}
-                hasVoted={hasVoted}
+                hasVoted={hasVoted || anonymousVoteSubmitted}
                 userVoteType={getUserVoteType()}
               />
             )}

--- a/client/src/components/Post/PostCard.jsx
+++ b/client/src/components/Post/PostCard.jsx
@@ -24,6 +24,7 @@ import gql from 'graphql-tag'
 import { tokenValidator } from 'store/user'
 import { useState, useMemo } from 'react'
 import useGuestGuard from '../../utils/useGuestGuard'
+import { getVisibleVotes } from '../../utils/votes'
 
 const GET_GROUP = gql`
   query getGroup($groupId: String!) {
@@ -310,6 +311,7 @@ function PostCard(props) {
   const dispatch = useDispatch()
   const history = useHistory()
   const user = useSelector((state) => state.user.data)
+  const showAnonymousVotes = useSelector((state) => state.ui.showAnonymousVotes)
   const classes = useStyles(props)
   const { width } = props
   
@@ -328,6 +330,7 @@ function PostCard(props) {
     activityType,
     limitText,
     votes,
+    anonymousVotes = [],
     comments,
     quotes,
     messageRoom,
@@ -342,6 +345,7 @@ function PostCard(props) {
   
   // Determine what text to show based on expanded state
   let postText = isExpanded || !shouldShowButton ? text : stringLimit(text, contentLimit)
+  const visibleVotes = getVisibleVotes(votes, anonymousVotes, showAnonymousVotes)
 
   let interactions = []
 
@@ -349,9 +353,13 @@ function PostCard(props) {
     interactions = interactions.concat(comments)
   }
 
-  if (!isEmpty(votes)) {
-    interactions = interactions.concat(votes)
-    postText = getTopPostsVoteHighlights(votes, postText, text)
+  if (!isEmpty(visibleVotes)) {
+    interactions = interactions.concat(visibleVotes)
+    postText = getTopPostsVoteHighlights(
+      visibleVotes,
+      postText,
+      text,
+    )
   }
 
   if (!isEmpty(quotes)) {
@@ -373,18 +381,18 @@ function PostCard(props) {
 
   // TODO: show quote up/down
   const { upQuote, downQuote } = useMemo(() => {
-    if (!votes || votes?.length === 0) {
-return {
+    if (!visibleVotes || visibleVotes.length === 0) {
+      return {
         upQuote: 0,
         downQuote: 0,
       }
     }
 
     return {
-      upQuote: votes.filter((vote) => vote.type === 'UPVOTE' || vote.type?.toUpperCase() === 'UP').length,
-      downQuote: votes.filter((vote) => vote.type === 'DOWNVOTE' || vote.type?.toUpperCase() === 'DOWN').length,
+      upQuote: visibleVotes.filter((vote) => vote.type === 'UPVOTE' || vote.type?.toUpperCase() === 'UP').length,
+      downQuote: visibleVotes.filter((vote) => vote.type === 'DOWNVOTE' || vote.type?.toUpperCase() === 'DOWN').length,
     }
-  }, [votes])
+  }, [visibleVotes])
 
   const { data: groupData, loading: groupLoading, error: groupError } = useQuery(GET_GROUP, {
     variables: { groupId },

--- a/client/src/components/PostActions/PostActionCard.jsx
+++ b/client/src/components/PostActions/PostActionCard.jsx
@@ -14,7 +14,13 @@ import SweetAlert from 'react-bootstrap-sweetalert'
 import AvatarDisplay from '../Avatar'
 import { parseCommentDate } from '../../utils/momentUtils'
 import { SET_FOCUSED_COMMENT, SET_SHARED_COMMENT, SET_SNACKBAR } from '../../store/ui'
-import { DELETE_VOTE, DELETE_COMMENT, DELETE_QUOTE } from '../../graphql/mutations'
+import {
+  DELETE_VOTE,
+  DELETE_COMMENT,
+  DELETE_QUOTE,
+  VOTE,
+  ADD_ANONYMOUS_VOTE,
+} from '../../graphql/mutations'
 import { GET_ACTION_REACTIONS } from '../../graphql/query'
 import CommentReactions from '../Comment/CommentReactions'
 import PostChatMessage from '../PostChat/PostChatMessage'
@@ -22,6 +28,7 @@ import LikeIcon from '../../assets/svg/Like.jsx'
 import DislikeIcon from '../../assets/svg/Dislike.jsx'
 import { SvgIcon } from '@material-ui/core'
 import buttonStyle from '../../assets/jss/material-dashboard-pro-react/components/buttonStyle'
+import { getVisibleVotes, getVoteCounts } from '../../utils/votes'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -73,6 +80,26 @@ const useStyles = makeStyles((theme) => ({
     fontSize: '0.85em',
     color: '#888',
   },
+  voteButtons: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    marginLeft: theme.spacing(1),
+  },
+  voteCount: {
+    fontSize: '0.85rem',
+    fontWeight: 600,
+  },
+  anonymousBadge: {
+    display: 'inline-block',
+    marginLeft: theme.spacing(1),
+    padding: '2px 8px',
+    borderRadius: 999,
+    fontSize: '0.75rem',
+    fontWeight: 700,
+    color: '#555',
+    backgroundColor: 'rgba(0, 0, 0, 0.06)',
+  },
   deleteIcon: {
     color: '#f44336',
   },
@@ -81,12 +108,19 @@ const useStyles = makeStyles((theme) => ({
 
 function PostActionCard({ postAction, postUrl, selected, refetchPost }) {
   const [commentSelected, setCommentSelected] = useState()
+  const [anonymousCommentVoteSubmitted, setAnonymousCommentVoteSubmitted] = useState(false)
   const history = useHistory()
   const classes = useStyles()
   const dispatch = useDispatch()
   const user = useSelector((state) => state.user.data)
-  const { user: actionUser, content, created, _id } = postAction
-  const { username, avatar, name } = actionUser
+  const showAnonymousVotes = useSelector((state) => state.ui.showAnonymousVotes)
+  const { user: actionUser = {}, content, created, _id } = postAction
+  const {
+    username,
+    avatar,
+    name,
+    _id: actionUserId,
+  } = actionUser
   const parsedDate = parseCommentDate(created)
   const voteType = get(postAction, 'type')
   const quote = get(postAction, 'quote')
@@ -110,6 +144,18 @@ function PostActionCard({ postAction, postUrl, selected, refetchPost }) {
   let postContent = content
   let svgIcon
   let voteTags = ''
+  const visibleCommentVotes = getVisibleVotes(
+    postAction.votes || [],
+    postAction.anonymousVotes || [],
+    showAnonymousVotes,
+  )
+  const { up: upVoteCount, down: downVoteCount } = getVoteCounts(visibleCommentVotes)
+  const isAuthenticated = Boolean(user._id)
+  const hasAuthenticatedCommentVote =
+    type === 'Comment' &&
+    Array.isArray(postAction.votes) &&
+    postAction.votes.some((vote) => vote.userId === user._id)
+  const commentVoteLocked = hasAuthenticatedCommentVote || anonymousCommentVoteSubmitted
 
   const [deleteVote] = useMutation(DELETE_VOTE, {
     update(cache, { data: { deleteVote } }) {
@@ -152,6 +198,8 @@ function PostActionCard({ postAction, postUrl, selected, refetchPost }) {
       })
     },
   })
+  const [addVote] = useMutation(VOTE)
+  const [addAnonymousVote] = useMutation(ADD_ANONYMOUS_VOTE)
 
   const handleDelete = async () => {
     try {
@@ -197,6 +245,55 @@ function PostActionCard({ postAction, postUrl, selected, refetchPost }) {
     }
   }
 
+  const handleCommentVote = async (nextVoteType) => {
+    if (type !== 'Comment' || commentVoteLocked) {
+      return
+    }
+
+    const vote = {
+      postId: postAction.postId,
+      commentId: _id,
+      content: postAction.content,
+      type: nextVoteType,
+      tags: nextVoteType === 'up' ? '#agree' : '#disagree',
+      startWordIndex: 0,
+      endWordIndex: 0,
+    }
+
+    try {
+      if (isAuthenticated) {
+        await addVote({
+          variables: {
+            vote: {
+              ...vote,
+              userId: user._id,
+            },
+          },
+        })
+      } else {
+        await addAnonymousVote({ variables: { vote } })
+        setAnonymousCommentVoteSubmitted(true)
+      }
+
+      dispatch(
+        SET_SNACKBAR({
+          open: true,
+          message: 'Vote recorded successfully',
+          type: 'success',
+        }),
+      )
+      if (refetchPost) refetchPost()
+    } catch (err) {
+      dispatch(
+        SET_SNACKBAR({
+          open: true,
+          message: `Vote Error: ${err.message}`,
+          type: 'danger',
+        }),
+      )
+    }
+  }
+
   const handleClick = useCallback(() => {
     if (!commentSelected) {
       dispatch(SET_FOCUSED_COMMENT(postAction))
@@ -208,6 +305,9 @@ function PostActionCard({ postAction, postUrl, selected, refetchPost }) {
   }, [commentSelected, dispatch, postAction, sharedComment])
 
   const handleRedirectToProfile = () => {
+    if (!username) {
+      return
+    }
     history.push(`/Profile/${username}`)
   }
 
@@ -239,8 +339,8 @@ function PostActionCard({ postAction, postUrl, selected, refetchPost }) {
       className={selected ? classes.selectedRoot : classes.root}
     >
       <div className={classes.userContainer}>
-        <IconButton onClick={() => handleRedirectToProfile()}>
-          <AvatarDisplay height={20} width={20} {...avatar} />
+        <IconButton onClick={() => handleRedirectToProfile()} disabled={!username}>
+          <AvatarDisplay height={20} width={20} {...(avatar || {})} />
         </IconButton>
 
         <Typography display="inline" className={classes.userInfo}>
@@ -251,13 +351,16 @@ function PostActionCard({ postAction, postUrl, selected, refetchPost }) {
               handleRedirectToProfile();
             }}
           >
-            {name}
-            {type === 'Vote' && username}
+            {type === 'AnonymousVote' ? 'Anonymous voter' : (name || username || 'Unknown user')}
+            {type === 'Vote' && username ? ` @${username}` : ''}
           </span>
+          {type === 'AnonymousVote' && (
+            <span className={classes.anonymousBadge}>Anonymous</span>
+          )}
           <span className={classes.date}>{parsedDate}</span>
         </Typography>
       </div>
-      {type === 'Vote' && (
+      {(type === 'Vote' || type === 'AnonymousVote') && (
         <CardContent className={classes.content}>
           <Typography display="inline">
             {`❝ ${postAction.content ? postAction.content : '(no text selected)'} ❞`}
@@ -280,20 +383,44 @@ function PostActionCard({ postAction, postUrl, selected, refetchPost }) {
         </CardContent>
       )}
       <CardActions disableSpacing>
-        <SvgIcon
-          component={svgIcon}
-          fontSize="large"
-          viewBox="-10 -10 50 50"
-          htmlColor="black"
-        />
-        <Typography display="inline">{voteTags}</Typography>
+        {(type === 'Vote' || type === 'AnonymousVote') && (
+          <>
+            <SvgIcon
+              component={svgIcon}
+              fontSize="large"
+              viewBox="-10 -10 50 50"
+              htmlColor="black"
+            />
+            <Typography display="inline">{voteTags}</Typography>
+          </>
+        )}
+        {type === 'Comment' && (
+          <div className={classes.voteButtons}>
+            <IconButton
+              size="small"
+              onClick={() => handleCommentVote('up')}
+              disabled={commentVoteLocked}
+            >
+              <SvgIcon component={LikeIcon} viewBox="0 0 30 30" />
+            </IconButton>
+            <Typography className={classes.voteCount}>{upVoteCount}</Typography>
+            <IconButton
+              size="small"
+              onClick={() => handleCommentVote('down')}
+              disabled={commentVoteLocked}
+            >
+              <SvgIcon component={DislikeIcon} viewBox="0 0 30 30" />
+            </IconButton>
+            <Typography className={classes.voteCount}>{downVoteCount}</Typography>
+          </div>
+        )}
         <div className={classes.expand}>
           <CommentReactions actionId={_id} reactions={actionReactions} />
         </div>
         <IconButton onClick={handleCopy}>
           <InsertLink />
         </IconButton>
-        {(user._id === actionUser._id || user.admin) && (
+        {(actionUserId && (user._id === actionUserId || user.admin)) && (
           <IconButton onClick={handleDelete} className={classes.deleteIcon}>
             <Delete />
           </IconButton>

--- a/client/src/components/RequestInviteDialog.jsx
+++ b/client/src/components/RequestInviteDialog.jsx
@@ -275,7 +275,7 @@ export default function RequestInviteDialog({ open, onClose }) {
                 }}
               >
                 You need an account to contribute. Viewing is public, but
-                posting, voting, and quoting require an invite.
+                posting, commenting, and quoting require an invite.
               </Typography>
 
               <div className={classes.emailInputWrapper}>

--- a/client/src/config/apollo.js
+++ b/client/src/config/apollo.js
@@ -12,6 +12,7 @@ import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { createClient } from 'graphql-ws'
 import { serializeObjectIds } from '../utils/objectIdSerializer'
 import { getGraphqlServerUrl, getGraphqlWsServerUrl } from '../utils/getServerUrl'
+import { getAnonymousSessionId } from '../utils/anonymousSession'
 
 // Determine if we're using a local server
 let isLocalServer = false
@@ -42,6 +43,7 @@ const authLink = new ApolloLink((operation, forward) => {
   // Build headers object
   const headers = {
     'Content-Type': 'application/json',
+    'x-anonymous-session-id': getAnonymousSessionId(),
     ...operation.getContext().headers,
   }
 
@@ -70,6 +72,7 @@ const wsLink = typeof window !== 'undefined' ? new GraphQLWsLink(createClient({
   url: getGraphqlWsServerUrl(),
   connectionParams: () => ({
     authToken: `Bearer ${localStorage.getItem('token')}`,
+    anonymousSessionId: getAnonymousSessionId(),
   }),
   retryAttempts: MAX_RETRY_ATTEMPTS, // Limit retry attempts
   shouldRetry: (errOrCloseEvent) => {

--- a/client/src/graphql/mutations.jsx
+++ b/client/src/graphql/mutations.jsx
@@ -47,7 +47,19 @@ export const VOTE = gql`
   mutation addVote($vote: VoteInput!) {
     addVote(vote: $vote) {
       postId
+      commentId
       type
+    }
+  }
+`
+
+export const ADD_ANONYMOUS_VOTE = gql`
+  mutation addAnonymousVote($vote: VoteInput!) {
+    addAnonymousVote(vote: $vote) {
+      postId
+      commentId
+      type
+      anonymous
     }
   }
 `

--- a/client/src/graphql/query.jsx
+++ b/client/src/graphql/query.jsx
@@ -79,6 +79,18 @@ export const GET_POST = gql`
           avatar
           contributorBadge
         }
+        votes {
+          _id
+          type
+          userId
+          commentId
+        }
+        anonymousVotes {
+          _id
+          type
+          commentId
+          anonymous
+        }
       }
       votes {
         _id
@@ -95,6 +107,16 @@ export const GET_POST = gql`
           avatar
           contributorBadge
         }
+      }
+      anonymousVotes {
+        _id
+        startWordIndex
+        endWordIndex
+        created
+        type
+        tags
+        content
+        anonymous
       }
       quotes {
         _id
@@ -274,6 +296,13 @@ export const GET_TOP_POSTS = gql`
           endWordIndex
           type
         }
+        anonymousVotes {
+          _id
+          startWordIndex
+          endWordIndex
+          type
+          anonymous
+        }
         comments {
           _id
         }
@@ -346,6 +375,13 @@ export const GET_PAGINATED_POSTS = gql`
           endWordIndex
           type
         }
+        anonymousVotes {
+          _id
+          startWordIndex
+          endWordIndex
+          type
+          anonymous
+        }
         comments {
           _id
         }
@@ -409,6 +445,13 @@ export const GET_FRIENDS_POSTS = gql`
           startWordIndex
           endWordIndex
           type
+        }
+        anonymousVotes {
+          _id
+          startWordIndex
+          endWordIndex
+          type
+          anonymous
         }
         comments {
           _id
@@ -755,6 +798,13 @@ export const GET_FEATURED_POSTS = gql`
           startWordIndex
           endWordIndex
           type
+        }
+        anonymousVotes {
+          _id
+          startWordIndex
+          endWordIndex
+          type
+          anonymous
         }
         comments {
           _id

--- a/client/src/store/ui.js
+++ b/client/src/store/ui.js
@@ -27,6 +27,7 @@ export const uiInitialState = {
   selectedPlan: 'personal',
   focusedComment: null,
   sharedComment: null,
+  showAnonymousVotes: true,
 }
 
 const uiSlice = createSlice({
@@ -54,6 +55,9 @@ const uiSlice = createSlice({
     SET_SHARED_COMMENT: (state, action) => {
       state.sharedComment = action.payload
     },
+    SET_SHOW_ANONYMOUS_VOTES: (state, action) => {
+      state.showAnonymousVotes = action.payload
+    },
   },
 })
 
@@ -65,6 +69,7 @@ export const {
   SET_SELECTED_PLAN,
   SET_FOCUSED_COMMENT,
   SET_SHARED_COMMENT,
+  SET_SHOW_ANONYMOUS_VOTES,
 } = uiSlice.actions
 
 export default uiSlice.reducer

--- a/client/src/utils/anonymousSession.js
+++ b/client/src/utils/anonymousSession.js
@@ -1,0 +1,20 @@
+const ANONYMOUS_SESSION_STORAGE_KEY = 'anonymous-vote-session-id'
+
+export const getAnonymousSessionId = () => {
+  if (typeof window === 'undefined') {
+    return ''
+  }
+
+  const existingSessionId = localStorage.getItem(ANONYMOUS_SESSION_STORAGE_KEY)
+  if (existingSessionId) {
+    return existingSessionId
+  }
+
+  const sessionId =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `anon-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+  localStorage.setItem(ANONYMOUS_SESSION_STORAGE_KEY, sessionId)
+  return sessionId
+}

--- a/client/src/utils/votes.js
+++ b/client/src/utils/votes.js
@@ -1,0 +1,13 @@
+export const getVisibleVotes = (
+  votes = [],
+  anonymousVotes = [],
+  showAnonymousVotes = true,
+) => (showAnonymousVotes ? [...votes, ...anonymousVotes] : votes)
+
+export const getVoteCounts = (votes = []) => votes.reduce(
+  (result, vote) => ({
+    up: result.up + (vote.type === 'up' ? 1 : 0),
+    down: result.down + (vote.type === 'down' ? 1 : 0),
+  }),
+  { up: 0, down: 0 },
+)

--- a/client/src/views/PostsPage/PostPage.jsx
+++ b/client/src/views/PostsPage/PostPage.jsx
@@ -15,6 +15,7 @@ import { GET_ROOM_MESSAGES, GET_POST } from '../../graphql/query';
 import { NEW_MESSAGE_SUBSCRIPTION } from '../../graphql/subscription';
 import PostChatSend from '../../components/PostChat/PostChatSend';
 import { tokenValidator } from 'store/user';
+import { getVisibleVotes } from '../../utils/votes';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -247,6 +248,7 @@ function PostPage({ postId }) {
 
   const idSelector = useSelector((state) => state.ui.selectedPost.id)
   const user = useSelector((state) => state.user.data)
+  const showAnonymousVotes = useSelector((state) => state.ui.showAnonymousVotes)
 
   // Check if user is authenticated
   const isAuthenticated = user && user._id && tokenValidator(dispatch)
@@ -323,9 +325,10 @@ function PostPage({ postId }) {
 
   const { messages } = (!loadingMessages && messageData) || []
 
-  const { comments, votes, quotes } = post || {
+  const { comments, votes, anonymousVotes, quotes } = post || {
     comments: [],
     votes: [],
+    anonymousVotes: [],
     quotes: [],
   }
 
@@ -335,6 +338,12 @@ function PostPage({ postId }) {
   const filteredQuotes = quotes.filter((q) => !q.deleted)
   // Filter out deleted votes
   const filteredVotes = votes.filter((v) => !v.deleted)
+  const filteredAnonymousVotes = anonymousVotes.filter((v) => !v.deleted)
+  const visibleVotes = getVisibleVotes(
+    filteredVotes,
+    filteredAnonymousVotes,
+    showAnonymousVotes,
+  )
 
   const postActions = useMemo(() => {
     let postActions = []
@@ -344,6 +353,8 @@ function PostPage({ postId }) {
         filteredComments.map((comment) => ({
           ...comment,
           __typename: 'Comment',
+          votes: comment.votes || [],
+          anonymousVotes: comment.anonymousVotes || [],
           commentQuote:
             comment.endWordIndex > comment.startWordIndex
               ? post.text
@@ -354,11 +365,11 @@ function PostPage({ postId }) {
       )
     }
 
-    if (!isEmpty(filteredVotes)) {
+    if (!isEmpty(visibleVotes)) {
       postActions = postActions.concat(
-        filteredVotes.map((vote) => ({
+        visibleVotes.map((vote) => ({
           ...vote,
-          __typename: 'Vote',
+          __typename: vote.anonymous ? 'AnonymousVote' : 'Vote',
         }))
       )
     }
@@ -384,7 +395,7 @@ function PostPage({ postId }) {
     }
 
     return postActions
-  }, [comments, votes, quotes, messages])
+  }, [filteredComments, filteredQuotes, messages, post?.text, visibleVotes])
 
   const { url } = (!loadingPost && post) || {}
 

--- a/client/src/views/SearchPage/index.jsx
+++ b/client/src/views/SearchPage/index.jsx
@@ -752,6 +752,7 @@ export default function SearchPage() {
           creator={post.creator}
           activityType={post.activityType || 'POSTED'}
           votes={post.votes || []}
+          anonymousVotes={post.anonymousVotes || []}
           comments={post.comments || []}
           quotes={post.quotes || []}
           messageRoom={{ messages: post.messageRoom?.messages || [] }}

--- a/server/app/data/inputs/VoteInput.js
+++ b/server/app/data/inputs/VoteInput.js
@@ -2,6 +2,7 @@ export const VoteInput = `
 input VoteInput {
     postId: String!
     userId: String
+    commentId: String
     type: String!
     tags: String!
     startWordIndex: Int!

--- a/server/app/data/resolvers/models/AnonymousVoteModel.js
+++ b/server/app/data/resolvers/models/AnonymousVoteModel.js
@@ -5,15 +5,18 @@ const schema = mongoose.Schema({
     type: mongoose.Schema.Types.ObjectId,
     required: true,
   },
-  userId: {
-    type: mongoose.Schema.Types.ObjectId,
-    required: true,
-  },
   commentId: {
     type: mongoose.Schema.Types.ObjectId,
     required: false,
   },
-  // can be either up or down
+  sessionId: {
+    type: String,
+    required: true,
+  },
+  fingerprintHash: {
+    type: String,
+    required: true,
+  },
   type: {
     type: String,
     required: true,
@@ -44,6 +47,19 @@ const schema = mongoose.Schema({
   },
 });
 
-schema.index({ content: 'text' });
+schema.index({
+  postId: 1,
+  commentId: 1,
+  sessionId: 1,
+  deleted: 1,
+}, {
+  unique: true,
+  partialFilterExpression: {
+    deleted: { $ne: true },
+  },
+});
 
-export default mongoose.model('Votes', schema);
+schema.index({ content: 'text' });
+schema.index({ sessionId: 1, created: -1 });
+
+export default mongoose.model('AnonymousVotes', schema);

--- a/server/app/data/resolvers/mutations.js
+++ b/server/app/data/resolvers/mutations.js
@@ -32,6 +32,7 @@ export const resolver_mutations = function () {
 
     // Votes mutations
     addVote: voteMutations.addVote(),
+    addAnonymousVote: voteMutations.addAnonymousVote(),
     deleteVote: voteMutations.deleteVote(),
 
     // Comment mutations

--- a/server/app/data/resolvers/mutations/comment/addComment.js
+++ b/server/app/data/resolvers/mutations/comment/addComment.js
@@ -7,12 +7,17 @@ import { addNotification } from '~/resolvers/utils/notifications/addNotification
 import { addUserToPostRoom } from '../../utils/message/addUserToPostRoom';
 
 export const addComment = (pubsub) => {
-  return async (_, args) => {
+  return async (_, args, context) => {
     logger.info('Function: addComment');
+
+    if (!context.user || !context.user._id) {
+      throw new Error('Create an account to post or comment.');
+    }
 
     try {
       const comment = await new CommentModel({
         ...args.comment,
+        userId: context.user._id,
         created: new Date(),
       }).save();
 

--- a/server/app/data/resolvers/mutations/post/addPost.js
+++ b/server/app/data/resolvers/mutations/post/addPost.js
@@ -50,8 +50,12 @@ const sanitizeUrl = (url) => {
 };
 
 export const addPost = (pubsub) => {
-  return async (_, args) => {
+  return async (_, args, context) => {
     logger.info('Function: add post', { args });
+
+    if (!context.user || !context.user._id) {
+      throw new Error('Create an account to post or comment.');
+    }
 
     // Validation: Post body must NOT contain URLs
     URL_REGEX.lastIndex = 0;
@@ -77,6 +81,7 @@ export const addPost = (pubsub) => {
     // Create the post first to get the ID
     const postObj = {
       ...args.post,
+      userId: context.user._id,
       url: '', // Temporary URL, will be updated after creation
       citationUrl: sanitizedCitationUrl,
     };

--- a/server/app/data/resolvers/mutations/vote/addVote.js
+++ b/server/app/data/resolvers/mutations/vote/addVote.js
@@ -1,33 +1,139 @@
 import { logger } from '../../../utils/logger';
 import VoteModel from '../../models/VoteModel';
+import AnonymousVoteModel from '../../models/AnonymousVoteModel';
 import PostModel from '../../models/PostModel';
+import CommentModel from '../../models/CommentModel';
 import { updateScore } from './updateScore';
 import { logActivity } from '../../utils/activities_utils';
 import { addNotification } from '~/resolvers/utils/notifications/addNotification';
+import crypto from 'crypto';
+
+const ANONYMOUS_VOTE_WINDOW_MS = 30 * 1000;
+
+const getClientIp = (req) => {
+  const forwardedFor = req?.headers?.['x-forwarded-for'];
+  if (typeof forwardedFor === 'string' && forwardedFor.length > 0) {
+    return forwardedFor.split(',')[0].trim();
+  }
+
+  return req?.ip || req?.socket?.remoteAddress || 'unknown';
+};
+
+const buildAnonymousFingerprint = ({ sessionId, req }) => {
+  const userAgent = req?.headers?.['user-agent'] || 'unknown';
+  const ip = getClientIp(req);
+
+  return crypto
+    .createHash('sha256')
+    .update(`${sessionId}:${ip}:${userAgent}`)
+    .digest('hex');
+};
+
+const buildVoteData = async (voteInput, userId) => {
+  const voteData = {
+    ...voteInput,
+    userId,
+    created: new Date(),
+  };
+
+  if (voteInput.commentId) {
+    const comment = await CommentModel.findById(voteInput.commentId);
+    if (!comment || comment.deleted) {
+      throw new Error('Comment not found');
+    }
+
+    voteData.postId = comment.postId;
+    voteData.content = voteInput.content || comment.content;
+    voteData.startWordIndex = 0;
+    voteData.endWordIndex = 0;
+  }
+
+  return voteData;
+};
+
+const createAnonymousVote = async (voteInput, context) => {
+  const sessionId = context.req?.headers?.['x-anonymous-session-id'];
+  if (!sessionId || typeof sessionId !== 'string') {
+    throw new Error('Anonymous voting session not found');
+  }
+
+  const voteData = await buildVoteData(voteInput);
+  const scopeQuery = voteData.commentId
+    ? { commentId: voteData.commentId }
+    : { postId: voteData.postId };
+
+  const existingVote = await AnonymousVoteModel.findOne({
+    ...scopeQuery,
+    sessionId,
+    deleted: { $ne: true },
+  });
+
+  if (existingVote) {
+    throw new Error(
+      voteData.commentId
+        ? 'You have already voted on this comment'
+        : 'You have already voted on this post',
+    );
+  }
+
+  const recentVote = await AnonymousVoteModel.findOne({
+    sessionId,
+    created: { $gte: new Date(Date.now() - ANONYMOUS_VOTE_WINDOW_MS) },
+    deleted: { $ne: true },
+  });
+
+  if (recentVote) {
+    throw new Error('Please wait a few seconds before voting again');
+  }
+
+  const anonymousVote = await new AnonymousVoteModel({
+    ...voteData,
+    sessionId,
+    fingerprintHash: buildAnonymousFingerprint({ sessionId, req: context.req }),
+  }).save();
+
+  return {
+    ...anonymousVote.toObject(),
+    anonymous: true,
+  };
+};
 
 export const addVote = (pubsub) => {
-  return async (_, args) => {
+  return async (_, args, context) => {
     logger.info('Function: add vote');
-    const voteData = {
-      ...args.vote,
-      created: new Date(),
-    };
 
     try {
+      if (!context.user || !context.user._id) {
+        throw new Error('Authentication required');
+      }
+
+      const voteData = await buildVoteData(args.vote, context.user._id);
+      const scopeQuery = voteData.commentId
+        ? { commentId: voteData.commentId }
+        : { postId: voteData.postId };
+
       // Check if user has already voted on this post (ignore deleted votes)
       const existingVote = await VoteModel.findOne({
-        postId: voteData.postId,
+        ...scopeQuery,
         userId: voteData.userId,
         deleted: { $ne: true },
       });
 
       if (existingVote) {
-        throw new Error('You have already voted on this post');
+        throw new Error(
+          voteData.commentId
+            ? 'You have already voted on this comment'
+            : 'You have already voted on this post',
+        );
       }
 
       const vote = await new VoteModel(voteData).save();
-      await updateScore(vote);
+      if (!vote.commentId) {
+        await updateScore(vote);
+      }
+
       const post = await PostModel.findById(vote.postId);
+      const voteTarget = vote.commentId ? 'comment' : 'post';
       await logActivity(
         'VOTED',
         {
@@ -35,18 +141,32 @@ export const addVote = (pubsub) => {
           userId: vote.userId,
           voteId: vote._id,
         },
-        `${vote.type === 'up' ? 'Upvoted' : 'Downvoted'} '${post.title}' post.`,
+        `${vote.type === 'up' ? 'Upvoted' : 'Downvoted'} '${post.title}' ${voteTarget}.`,
       );
 
-      await addNotification({
-        userId: post.userId,
-        userIdBy: vote.userId,
-        label: post.text.substring(vote.startWordIndex, vote.endWordIndex),
-        notificationType: `${vote.type.toUpperCase()}VOTED`,
-        postId: vote.postId,
-      });
+      if (!vote.commentId) {
+        await addNotification({
+          userId: post.userId,
+          userIdBy: vote.userId,
+          label: post.text.substring(vote.startWordIndex, vote.endWordIndex),
+          notificationType: `${vote.type.toUpperCase()}VOTED`,
+          postId: vote.postId,
+        });
+      }
 
       return vote;
+    } catch (err) {
+      throw new Error(err);
+    }
+  };
+};
+
+export const addAnonymousVote = (pubsub) => {
+  return async (_, args, context) => {
+    logger.info('Function: add anonymous vote');
+
+    try {
+      return await createAnonymousVote(args.vote, context);
     } catch (err) {
       throw new Error(err);
     }

--- a/server/app/data/resolvers/relationship/comment_relationship.js
+++ b/server/app/data/resolvers/relationship/comment_relationship.js
@@ -1,4 +1,6 @@
 import { findUserById } from '~/resolvers/queries/user';
+import VoteModel from '~/resolvers/models/VoteModel';
+import AnonymousVoteModel from '~/resolvers/models/AnonymousVoteModel';
 
 export const commentRelationship = () => {
   return {
@@ -6,6 +8,20 @@ export const commentRelationship = () => {
       const { userId } = data;
       const result = await findUserById()(root, { user_id: userId });
       return result;
+    },
+    async votes(comment) {
+      return VoteModel.find({ commentId: comment._id, deleted: { $ne: true } });
+    },
+    async anonymousVotes(comment) {
+      const votes = await AnonymousVoteModel.find({
+        commentId: comment._id,
+        deleted: { $ne: true },
+      });
+
+      return votes.map((vote) => ({
+        ...vote.toObject(),
+        anonymous: true,
+      }));
     },
   };
 };

--- a/server/app/data/resolvers/relationship/post_relationship.js
+++ b/server/app/data/resolvers/relationship/post_relationship.js
@@ -2,6 +2,7 @@ import { ObjectId } from 'mongodb';
 import { findUserById } from '~/resolvers/queries/user';
 import CommentModel from '~/resolvers/models/CommentModel';
 import VoteModel from '~/resolvers/models/VoteModel';
+import AnonymousVoteModel from '~/resolvers/models/AnonymousVoteModel';
 import QuoteModel from '~/resolvers/models/QuoteModel';
 import MessageRoomModel from '~/resolvers/models/MessageRoomModel';
 
@@ -19,6 +20,13 @@ export const postRelationship = () => {
     async votes(post) {
       const votes = await VoteModel.find({ postId: post._id, deleted: { $ne: true } });
       return votes;
+    },
+    async anonymousVotes(post) {
+      const votes = await AnonymousVoteModel.find({ postId: post._id, deleted: { $ne: true } });
+      return votes.map((vote) => ({
+        ...vote.toObject(),
+        anonymous: true,
+      }));
     },
     async quotes(post) {
       const quotes = await QuoteModel.find({ postId: post._id, deleted: { $ne: true } });

--- a/server/app/data/type_definition/mutation_definition.js
+++ b/server/app/data/type_definition/mutation_definition.js
@@ -22,6 +22,9 @@ export const Mutation = `type Mutation {
   # Mutation for updating/inserting votes
   addVote(vote: VoteInput!): Vote
 
+  # Mutation for anonymous voting
+  addAnonymousVote(vote: VoteInput!): AnonymousVote
+
   # Mutation for deleting a vote
   deleteVote(voteId: String!): DeletedVote
 

--- a/server/app/data/types/AnonymousVote.js
+++ b/server/app/data/types/AnonymousVote.js
@@ -1,17 +1,14 @@
-export const Vote = `
-type Vote {
+export const AnonymousVote = `
+type AnonymousVote {
   _id: String
   created: Date
   postId: String
-  userId: String
   commentId: String
   type: String
   tags: String
   startWordIndex: Int
   endWordIndex: Int
   deleted: Boolean
-  user: User
   content: String
   anonymous: Boolean
-}
-`;
+}`;

--- a/server/app/data/types/Comment.js
+++ b/server/app/data/types/Comment.js
@@ -11,4 +11,6 @@ type Comment {
   reaction: String
   deleted: Boolean
   user: User
+  votes: [Vote]
+  anonymousVotes: [AnonymousVote]
 }`;

--- a/server/app/data/types/Post.js
+++ b/server/app/data/types/Post.js
@@ -23,6 +23,7 @@ type Post {
   creator: User
   comments: [Comment]
   votes: [Vote]
+  anonymousVotes: [AnonymousVote]
   quotes: [Quote]
   messageRoom: MessageRoom
 }`;

--- a/server/app/data/types/index.js
+++ b/server/app/data/types/index.js
@@ -15,6 +15,7 @@ export * from './User';
 export * from './UserInvite';
 export * from './UserReputation';
 export * from './Vote';
+export * from './AnonymousVote';
 export * from './DeletedPost';
 export * from './DeletedQuote';
 export * from './DeletedComment';

--- a/server/app/data/utils/requireAuth.js
+++ b/server/app/data/utils/requireAuth.js
@@ -21,6 +21,7 @@ const PUBLIC_QUERIES = [
   'getUserFollowInfo',
   'group',
   'groups',
+  'addAnonymousVote',
   // add more public queries/mutations
 ];
 

--- a/server/app/server.js
+++ b/server/app/server.js
@@ -216,10 +216,10 @@ const server = new ApolloServer({
       if (authToken && authToken.length) {
         try {
           const user = await verifyToken(authToken);
-          return { user, res };
+          return { user, res, req };
         } catch (error) {
           logger.debug('Invalid token, proceeding without user context:', error.message);
-          return { res };
+          return { res, req };
         }
       }
 
@@ -232,7 +232,7 @@ const server = new ApolloServer({
       }
     }
 
-    return { res };
+    return { res, req };
   },
 });
 


### PR DESCRIPTION
Allow logged-out visitors to vote on posts and comments without affecting trust signals, while giving signed-in users a toggle to hide anonymous totals across feeds and post discussions.
Made-with: Cursor
# Description
This PR adds anonymous voting for logged-out visitors while preserving accountability for authorship and discussion participation.
Anonymous users can now vote on posts and comments without creating an account, but anonymous votes are stored separately from authenticated votes and are excluded from reputation, moderation authority, and trust-related signals. Authenticated users can also control whether anonymous vote totals are displayed through a new `Show anonymous votes` toggle that applies consistently across feeds, post pages, and discussion views.
This change also keeps posting and commenting restricted to registered users only, and surfaces the required prompt when a guest attempts to post or comment.
## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactoring, documentation, or other non-functional changes)
## Related Issue
Closes the anonymous voting feature request for allowing logged-out visitors to vote on posts and comments while keeping posting/commenting restricted to registered users.
## Checklist:
- [x] I have read the [**Contributing Guidelines**](/CONTRIBUTING.md).
- [x] My code follows the [**Code Style**](/docs/contributing/code-style.md) of this project.
- [x] I have added tests that prove my fix is effective or that my feature works. See [**Testing Guidelines**](/docs/contributing/testing.md).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.