### PR TITLE
Fix/chat sidebar navigation links

### DIFF
--- a/client/src/components/BuddyList/BuddyItemList.jsx
+++ b/client/src/components/BuddyList/BuddyItemList.jsx
@@ -6,7 +6,14 @@ import ListItemText from '@material-ui/core/ListItemText'
 import ListItemAvatar from '@material-ui/core/ListItemAvatar'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import PropTypes from 'prop-types'
-import { Avatar, Typography, Tooltip, Badge, Chip, Fade } from '@material-ui/core'
+import {
+  Avatar,
+  Typography,
+  Tooltip,
+  Badge,
+  Chip,
+  Fade,
+} from '@material-ui/core'
 import classNames from 'classnames'
 import { useDispatch, useSelector } from 'react-redux'
 import { useRef, useState, useEffect } from 'react'
@@ -16,9 +23,10 @@ import GroupIcon from '@material-ui/icons/Group'
 import AvatarDisplay from '../Avatar'
 import PresenceIcon from '../Chat/PresenceIcon'
 import StatusMessage from '../Chat/StatusMessage'
-import { SELECTED_CHAT_ROOM } from '../../store/chat'
+import { SELECTED_CHAT_ROOM, SET_CHAT_OPEN } from '../../store/chat'
 import { SEND_MESSAGE } from '../../graphql/mutations'
 import { GET_CHAT_ROOMS } from '../../graphql/query'
+import { useHistory } from 'react-router-dom'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -154,6 +162,13 @@ const useStyles = makeStyles((theme) => ({
       marginBottom: theme.spacing(2),
     },
   },
+  nameLink: {
+    cursor: 'pointer',
+    '&:hover': {
+      textDecoration: 'underline',
+      color: theme.palette.primary.main,
+    },
+  },
 }))
 
 const emptyData = [
@@ -225,21 +240,43 @@ TruncatedText.propTypes = {
 function BuddyItemList({ buddyList }) {
   const classes = useStyles()
   const dispatch = useDispatch()
+  const history = useHistory()
   const currentUser = useSelector((state) => state.user?.data)
   const [createMessageRoom] = useMutation(SEND_MESSAGE, {
     refetchQueries: [{ query: GET_CHAT_ROOMS }],
   })
   const itemList = buddyList && buddyList.length ? buddyList : emptyData
-  
+
+  const handleNameClick = (e, item) => {
+    e.stopPropagation()
+    const itemType = item.type || (item.user ? 'USER' : 'POST')
+    if (itemType === 'USER' && item.user?.username) {
+      dispatch(SET_CHAT_OPEN(false))
+      history.push(`/Profile/${item.user.username}/`)
+    } else if (itemType === 'POST' && item.room?.postDetails?.url) {
+      dispatch(SET_CHAT_OPEN(false))
+      history.push(item.room.postDetails.url)
+    }
+  }
+
+  const getItemLinkTo = (item) => {
+    const itemType = item.type || (item.user ? 'USER' : 'POST')
+    if (itemType === 'USER' && item.user?.username)
+      return `/Profile/${item.user.username}/`
+    if (itemType === 'POST' && item.room?.postDetails?.url)
+      return item.room.postDetails.url
+    return null
+  }
+
   const handleClickItem = async (item) => {
     if (!buddyList.length || !currentUser) return
-    
+
     // If item has a room, use it
     if (item.room) {
       dispatch(SELECTED_CHAT_ROOM({ room: item.room }))
       return
     }
-    
+
     // If item has a user (from buddy list), create a message room
     if (item.user && item.user._id) {
       try {
@@ -265,12 +302,15 @@ function BuddyItemList({ buddyList }) {
       <Fade in timeout={500}>
         <div>
           <div className={classes.hint}>
-            <ChatBubbleOutlineIcon style={{ fontSize: 64, opacity: 0.2, marginBottom: 16 }} />
+            <ChatBubbleOutlineIcon
+              style={{ fontSize: 64, opacity: 0.2, marginBottom: 16 }}
+            />
             <Typography variant="h6" gutterBottom>
               <strong>No Conversations Yet</strong>
             </Typography>
             <Typography variant="body2">
-              Start chatting by adding friends!<br />
+              Start chatting by adding friends!
+              <br />
               Follow users to see them here.
             </Typography>
           </div>
@@ -279,21 +319,40 @@ function BuddyItemList({ buddyList }) {
               <Fade in timeout={300 + index * 100} key={index}>
                 <ListItem className={classes.listItem}>
                   <ListItemAvatar>
-                <Avatar className={classes.avatar}>
-                  {item.type === 'USER' && <AvatarDisplay height={40} width={40} {...item.avatar} />}
-                  {item.type !== 'USER' && item.Text[0]}
-                </Avatar>
+                    <Avatar className={classes.avatar}>
+                      {item.type === 'USER' && (
+                        <AvatarDisplay
+                          height={40}
+                          width={40}
+                          {...item.avatar}
+                        />
+                      )}
+                      {item.type !== 'USER' && item.Text[0]}
+                    </Avatar>
                   </ListItemAvatar>
                   <ListItemText
                     className={classes.listItemText}
                     primary={
                       <div className={classes.primaryText}>
-                        <TruncatedText text={item.Text} className={classes.textContent} />
+                        <TruncatedText
+                          text={item.Text}
+                          className={classes.textContent}
+                        />
                         <Chip
                           size="small"
-                          icon={item.type === 'USER' ? <ChatBubbleOutlineIcon /> : <GroupIcon />}
+                          icon={
+                            item.type === 'USER' ? (
+                              <ChatBubbleOutlineIcon />
+                            ) : (
+                              <GroupIcon />
+                            )
+                          }
                           label={item.type === 'USER' ? 'FRIEND' : 'POST'}
-                          className={item.type === 'USER' ? classes.friendChip : classes.postChip}
+                          className={
+                            item.type === 'USER'
+                              ? classes.friendChip
+                              : classes.postChip
+                          }
                         />
                       </div>
                     }
@@ -309,81 +368,140 @@ function BuddyItemList({ buddyList }) {
 
   return (
     <List className={classes.root}>
-      {itemList && itemList.length > 0 && itemList.map((item, index) => {
-        if (!item) return null;
-        
-        const itemText = item.Text || item.user?.name || item.user?.username || 'Unknown';
-        const itemType = item.type || (item.user ? 'USER' : 'POST');
-        const itemKey = item.room?._id || item.user?._id || item._id || index;
-        
-        return (
-          <Fade in timeout={200 + index * 50} key={itemKey}>
-            <ListItem className={classes.listItem} onClick={() => handleClickItem(item)}>
-              <ListItemAvatar>
-                <Badge
-                  overlap="circular"
-                  anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-                  variant="dot"
-                  invisible={!item.unreadMessages || item.unreadMessages === 0}
-                  sx={{
-                    '& .MuiBadge-badge': {
-                      backgroundColor: '#44b700',
-                      color: '#44b700',
-                      boxShadow: `0 0 0 2px #fff`,
-                    },
-                  }}
-                >
-                  <Avatar className={classes.avatar}>
-                    {itemType === 'USER' && item.user && (
-                      <AvatarDisplay height={40} width={40} {...(item.user.avatar || {})} />
-                    )}
-                    {itemType !== 'USER' && itemText && itemText[0]}
-                  </Avatar>
-                </Badge>
-              </ListItemAvatar>
-              <ListItemText
-                className={classes.listItemText}
-                primary={
-                  <div className={classes.primaryText}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
-                      {item.presence && (
-                        <PresenceIcon status={item.presence.status || 'offline'} />
+      {itemList &&
+        itemList.length > 0 &&
+        itemList.map((item, index) => {
+          if (!item) return null
+
+          const itemText =
+            item.Text || item.user?.name || item.user?.username || 'Unknown'
+          const itemType = item.type || (item.user ? 'USER' : 'POST')
+          const itemKey = item.room?._id || item.user?._id || item._id || index
+          const linkTo = getItemLinkTo(item)
+
+          return (
+            <Fade in timeout={200 + index * 50} key={itemKey}>
+              <ListItem
+                className={classes.listItem}
+                onClick={() => handleClickItem(item)}
+              >
+                <ListItemAvatar>
+                  <Badge
+                    overlap="circular"
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                    variant="dot"
+                    invisible={
+                      !item.unreadMessages || item.unreadMessages === 0
+                    }
+                    sx={{
+                      '& .MuiBadge-badge': {
+                        backgroundColor: '#44b700',
+                        color: '#44b700',
+                        boxShadow: `0 0 0 2px #fff`,
+                      },
+                    }}
+                  >
+                    <Avatar className={classes.avatar}>
+                      {itemType === 'USER' && item.user && (
+                        <AvatarDisplay
+                          height={40}
+                          width={40}
+                          {...(item.user.avatar || {})}
+                        />
                       )}
-                      <TruncatedText text={itemText} className={classes.textContent} />
+                      {itemType !== 'USER' && itemText && itemText[0]}
+                    </Avatar>
+                  </Badge>
+                </ListItemAvatar>
+                <ListItemText
+                  className={classes.listItemText}
+                  primary={
+                    <div className={classes.primaryText}>
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 8,
+                          flex: 1,
+                          minWidth: 0,
+                        }}
+                      >
+                        {item.presence && (
+                          <PresenceIcon
+                            status={item.presence.status || 'offline'}
+                          />
+                        )}
+                        <div
+                          className={linkTo ? classes.nameLink : undefined}
+                          onClick={
+                            linkTo ? (e) => handleNameClick(e, item) : undefined
+                          }
+                          role={linkTo ? 'link' : undefined}
+                          tabIndex={linkTo ? 0 : undefined}
+                          onKeyDown={
+                            linkTo
+                              ? (e) => {
+                                  if (e.key === 'Enter')
+                                    handleNameClick(e, item)
+                                }
+                              : undefined
+                          }
+                        >
+                          <TruncatedText
+                            text={itemText}
+                            className={classes.textContent}
+                          />
+                        </div>
+                      </div>
+                      <Chip
+                        size="small"
+                        icon={
+                          itemType === 'USER' ? (
+                            <ChatBubbleOutlineIcon />
+                          ) : (
+                            <GroupIcon />
+                          )
+                        }
+                        label={itemType === 'USER' ? 'FRIEND' : 'POST'}
+                        className={
+                          itemType === 'USER'
+                            ? classes.friendChip
+                            : classes.postChip
+                        }
+                      />
                     </div>
-                    <Chip
-                      size="small"
-                      icon={itemType === 'USER' ? <ChatBubbleOutlineIcon /> : <GroupIcon />}
-                      label={itemType === 'USER' ? 'FRIEND' : 'POST'}
-                      className={itemType === 'USER' ? classes.friendChip : classes.postChip}
-                    />
-                  </div>
-                }
-                secondary={
-                  item.statusMessage ? (
-                    <StatusMessage message={item.statusMessage} />
-                  ) : item.presence?.status === 'away' ? (
-                    <Typography variant="caption" style={{ fontStyle: 'italic', color: '#ffc107' }}>
-                      Away
-                    </Typography>
-                  ) : item.presence?.status === 'dnd' ? (
-                    <Typography variant="caption" style={{ fontStyle: 'italic', color: '#f44336' }}>
-                      Do Not Disturb
-                    </Typography>
-                  ) : null
-                }
-              />
-              {item.unreadMessages > 0 && (
-                <ListItemSecondaryAction>
-                  <div className={classes.unreadBadge}>
-                    {item.unreadMessages > 99 ? '99+' : item.unreadMessages}
-                  </div>
-                </ListItemSecondaryAction>
-              )}
-            </ListItem>
-          </Fade>
-        );
-      })}
+                  }
+                  secondary={
+                    item.statusMessage ? (
+                      <StatusMessage message={item.statusMessage} />
+                    ) : item.presence?.status === 'away' ? (
+                      <Typography
+                        variant="caption"
+                        style={{ fontStyle: 'italic', color: '#ffc107' }}
+                      >
+                        Away
+                      </Typography>
+                    ) : item.presence?.status === 'dnd' ? (
+                      <Typography
+                        variant="caption"
+                        style={{ fontStyle: 'italic', color: '#f44336' }}
+                      >
+                        Do Not Disturb
+                      </Typography>
+                    ) : null
+                  }
+                />
+                {item.unreadMessages > 0 && (
+                  <ListItemSecondaryAction>
+                    <div className={classes.unreadBadge}>
+                      {item.unreadMessages > 99 ? '99+' : item.unreadMessages}
+                    </div>
+                  </ListItemSecondaryAction>
+                )}
+              </ListItem>
+            </Fade>
+          )
+        })}
     </List>
   )
 }

--- a/client/src/components/Chat/ChatList.jsx
+++ b/client/src/components/Chat/ChatList.jsx
@@ -1,14 +1,24 @@
-import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
-import { useQuery } from '@apollo/react-hooks';
-import { useDispatch, useSelector } from 'react-redux';
-import { makeStyles, List, ListItem, ListItemAvatar, ListItemText, Typography, Avatar, Chip } from '@material-ui/core';
-import ChatBubbleOutlineIcon from '@material-ui/icons/ChatBubbleOutline';
-import GroupIcon from '@material-ui/icons/Group';
-import { GET_CHAT_ROOMS, GET_USER } from '../../graphql/query';
-import { SELECTED_CHAT_ROOM } from '../../store/chat';
-import LoadingSpinner from '../LoadingSpinner';
-import AvatarDisplay from '../Avatar';
+import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+import { useQuery } from '@apollo/react-hooks'
+import { useDispatch, useSelector } from 'react-redux'
+import {
+  makeStyles,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+  Avatar,
+  Chip,
+} from '@material-ui/core'
+import ChatBubbleOutlineIcon from '@material-ui/icons/ChatBubbleOutline'
+import GroupIcon from '@material-ui/icons/Group'
+import { useHistory } from 'react-router-dom'
+import { GET_CHAT_ROOMS, GET_USER } from '../../graphql/query'
+import { SELECTED_CHAT_ROOM, SET_CHAT_OPEN } from '../../store/chat'
+import LoadingSpinner from '../LoadingSpinner'
+import AvatarDisplay from '../Avatar'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -37,31 +47,45 @@ const useStyles = makeStyles((theme) => ({
     transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
     border: `1px solid transparent`,
     backgroundColor: theme.palette.mode === 'dark' ? '#2A2A2A' : '#ffffff',
-    boxShadow: theme.palette.mode === 'dark'
-      ? '0 1px 3px rgba(0, 0, 0, 0.2)'
-      : '0 1px 3px rgba(0, 0, 0, 0.04)',
+    boxShadow:
+      theme.palette.mode === 'dark'
+        ? '0 1px 3px rgba(0, 0, 0, 0.2)'
+        : '0 1px 3px rgba(0, 0, 0, 0.04)',
     '&:hover': {
       backgroundColor: theme.palette.mode === 'dark' ? '#333333' : '#f8fafc',
-      borderColor: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.1)' : theme.palette.grey[200],
+      borderColor:
+        theme.palette.mode === 'dark'
+          ? 'rgba(255, 255, 255, 0.1)'
+          : theme.palette.grey[200],
       transform: 'translateX(4px)',
-      boxShadow: theme.palette.mode === 'dark'
-        ? '0 4px 12px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.2)'
-        : '0 4px 12px rgba(0, 0, 0, 0.08), 0 2px 4px rgba(0, 0, 0, 0.04)',
+      boxShadow:
+        theme.palette.mode === 'dark'
+          ? '0 4px 12px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.2)'
+          : '0 4px 12px rgba(0, 0, 0, 0.08), 0 2px 4px rgba(0, 0, 0, 0.04)',
     },
   },
   selectedItem: {
-    background: theme.palette.mode === 'dark'
-      ? 'linear-gradient(135deg, rgba(82, 178, 116, 0.2) 0%, rgba(74, 158, 99, 0.15) 100%)'
-      : 'linear-gradient(135deg, rgba(82, 178, 116, 0.1) 0%, rgba(74, 158, 99, 0.08) 100%)',
-    borderColor: theme.palette.mode === 'dark' ? 'rgba(82, 178, 116, 0.4)' : '#52b274' + '60',
-    boxShadow: theme.palette.mode === 'dark'
-      ? '0 4px 12px rgba(82, 178, 116, 0.25), 0 2px 4px rgba(82, 178, 116, 0.15)'
-      : '0 4px 12px rgba(82, 178, 116, 0.15), 0 2px 4px rgba(82, 178, 116, 0.1)',
+    background:
+      theme.palette.mode === 'dark'
+        ? 'linear-gradient(135deg, rgba(82, 178, 116, 0.2) 0%, rgba(74, 158, 99, 0.15) 100%)'
+        : 'linear-gradient(135deg, rgba(82, 178, 116, 0.1) 0%, rgba(74, 158, 99, 0.08) 100%)',
+    borderColor:
+      theme.palette.mode === 'dark'
+        ? 'rgba(82, 178, 116, 0.4)'
+        : '#52b274' + '60',
+    boxShadow:
+      theme.palette.mode === 'dark'
+        ? '0 4px 12px rgba(82, 178, 116, 0.25), 0 2px 4px rgba(82, 178, 116, 0.15)'
+        : '0 4px 12px rgba(82, 178, 116, 0.15), 0 2px 4px rgba(82, 178, 116, 0.1)',
     '&:hover': {
-      background: theme.palette.mode === 'dark'
-        ? 'linear-gradient(135deg, rgba(82, 178, 116, 0.25) 0%, rgba(74, 158, 99, 0.2) 100%)'
-        : 'linear-gradient(135deg, rgba(82, 178, 116, 0.15) 0%, rgba(74, 158, 99, 0.12) 100%)',
-      borderColor: theme.palette.mode === 'dark' ? 'rgba(82, 178, 116, 0.5)' : '#52b274' + '80',
+      background:
+        theme.palette.mode === 'dark'
+          ? 'linear-gradient(135deg, rgba(82, 178, 116, 0.25) 0%, rgba(74, 158, 99, 0.2) 100%)'
+          : 'linear-gradient(135deg, rgba(82, 178, 116, 0.15) 0%, rgba(74, 158, 99, 0.12) 100%)',
+      borderColor:
+        theme.palette.mode === 'dark'
+          ? 'rgba(82, 178, 116, 0.5)'
+          : '#52b274' + '80',
       transform: 'translateX(4px)',
     },
   },
@@ -110,7 +134,8 @@ const useStyles = makeStyles((theme) => ({
     fontSize: '0.75rem',
     fontWeight: 700,
     padding: '0 8px',
-    boxShadow: '0 3px 10px rgba(82, 178, 116, 0.4), 0 1px 3px rgba(82, 178, 116, 0.3)',
+    boxShadow:
+      '0 3px 10px rgba(82, 178, 116, 0.4), 0 1px 3px rgba(82, 178, 116, 0.3)',
     border: '2px solid white',
   },
   typeChip: {
@@ -132,63 +157,75 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     gap: theme.spacing(0.5),
   },
-}));
+  nameLink: {
+    cursor: 'pointer',
+    '&:hover': {
+      textDecoration: 'underline',
+      color: theme.palette.primary.main,
+    },
+  },
+}))
 
 const ChatList = ({ search, filterType }) => {
-  const classes = useStyles();
-  const dispatch = useDispatch();
-  const currentUser = useSelector((state) => state.user.data);
-  const selectedRoom = useSelector((state) => state.chat.selectedRoom);
-  const [userCache, setUserCache] = useState({});
+  const classes = useStyles()
+  const dispatch = useDispatch()
+  const history = useHistory()
+  const currentUser = useSelector((state) => state.user.data)
+  const selectedRoom = useSelector((state) => state.chat.selectedRoom)
+  const [userCache, setUserCache] = useState({})
 
   const { loading, data, refetch } = useQuery(GET_CHAT_ROOMS, {
     fetchPolicy: 'cache-and-network',
     pollInterval: 10000, // Poll every 10 seconds for new messages
-  });
+  })
 
   useEffect(() => {
-    refetch();
-  }, [refetch]);
+    refetch()
+  }, [refetch])
 
-  if (loading && !data) return <LoadingSpinner size={50} />;
+  if (loading && !data) return <LoadingSpinner size={50} />
 
-  const rooms = data?.messageRooms || [];
+  const rooms = data?.messageRooms || []
 
   // Filter by type
   const filteredRooms = rooms.filter((room) => {
     if (filterType === 'chats') {
       // Direct messages - USER type with 2 users
-      return room.messageType === 'USER' && room.users?.length === 2;
+      return room.messageType === 'USER' && room.users?.length === 2
     } else if (filterType === 'groups') {
       // Group chats - POST type or more than 2 users
-      return room.messageType === 'POST' || room.users?.length > 2;
+      return room.messageType === 'POST' || room.users?.length > 2
     }
-    return true;
-  });
+    return true
+  })
 
   // Filter by search (simplified - just filter by title for now)
   const searchFiltered = search
     ? filteredRooms.filter((room) => {
-      const title = room.title || '';
-      return title.toLowerCase().includes(search.toLowerCase());
-    })
-    : filteredRooms;
+        const title = room.title || ''
+        return title.toLowerCase().includes(search.toLowerCase())
+      })
+    : filteredRooms
 
   // Sort by last message time (most recent first), fallback to lastActivity, then created
   const sortedRooms = [...searchFiltered].sort((a, b) => {
     // Use lastMessageTime if available, otherwise use lastActivity, then created
     const aTime = a.lastMessageTime
       ? new Date(a.lastMessageTime).getTime()
-      : (a.lastActivity ? new Date(a.lastActivity).getTime() : new Date(a.created).getTime());
+      : a.lastActivity
+      ? new Date(a.lastActivity).getTime()
+      : new Date(a.created).getTime()
     const bTime = b.lastMessageTime
       ? new Date(b.lastMessageTime).getTime()
-      : (b.lastActivity ? new Date(b.lastActivity).getTime() : new Date(b.created).getTime());
-    return bTime - aTime; // Most recent first
-  });
+      : b.lastActivity
+      ? new Date(b.lastActivity).getTime()
+      : new Date(b.created).getTime()
+    return bTime - aTime // Most recent first
+  })
 
   const handleRoomClick = (room) => {
-    dispatch(SELECTED_CHAT_ROOM({ room }));
-  };
+    dispatch(SELECTED_CHAT_ROOM({ room }))
+  }
 
   const getRoomDisplayInfo = (room) => {
     if (room.messageType === 'USER' && room.users?.length === 2) {
@@ -197,18 +234,22 @@ const ChatList = ({ search, filterType }) => {
         name: room.title || 'Direct Message',
         avatar: room.avatar || null, // Use avatar from room (resolved by messageRoomRelationship)
         subtitle: `${room.users?.length || 0} participants`,
-      };
+        linkTo: room.otherUsername ? `/Profile/${room.otherUsername}/` : null,
+      }
     } else if (room.messageType === 'POST') {
       // Group chat for post - show post title
-      const postTitle = room.postDetails?.title || room.title || 'Quote Discussion';
-      const postText = room.postDetails?.text || '';
-      const preview = postText.length > 50 ? `${postText.substring(0, 50)}...` : postText;
+      const postTitle =
+        room.postDetails?.title || room.title || 'Quote Discussion'
+      const postText = room.postDetails?.text || ''
+      const preview =
+        postText.length > 50 ? `${postText.substring(0, 50)}...` : postText
       return {
         name: postTitle,
         avatar: room.avatar || null, // Use avatar from room (will be set by server resolver for group chats)
         subtitle: preview || `${room.users?.length || 0} participants`,
         isGroup: true, // Flag to show group icon if no avatar
-      };
+        linkTo: room.postDetails?.url || null,
+      }
     } else {
       // Other group chat - show title or default
       return {
@@ -216,46 +257,63 @@ const ChatList = ({ search, filterType }) => {
         avatar: room.avatar || null, // Use avatar from room
         subtitle: `${room.users?.length || 0} members`,
         isGroup: true, // Flag to show group icon if no avatar
-      };
+        linkTo: null,
+      }
     }
-  };
+  }
+
+  const handleNameClick = (e, linkTo) => {
+    e.stopPropagation()
+    if (linkTo) {
+      dispatch(SET_CHAT_OPEN(false))
+      history.push(linkTo)
+    }
+  }
 
   if (sortedRooms.length === 0) {
     return (
       <div className={classes.noMessages}>
         <ChatBubbleOutlineIcon />
-        <Typography variant="h6" style={{ fontWeight: 600, marginBottom: 8, marginTop: 16 }}>
-          {search
-            ? `No ${filterType} found`
-            : `No ${filterType} yet`}
+        <Typography
+          variant="h6"
+          style={{ fontWeight: 600, marginBottom: 8, marginTop: 16 }}
+        >
+          {search ? `No ${filterType} found` : `No ${filterType} yet`}
         </Typography>
         <Typography variant="body2" style={{ opacity: 0.7 }}>
           {search
             ? `Try a different search term`
             : filterType === 'chats'
-              ? 'Add a buddy and start a conversation!'
-              : 'Create a group or post to start chatting'}
+            ? 'Add a buddy and start a conversation!'
+            : 'Create a group or post to start chatting'}
         </Typography>
       </div>
-    );
+    )
   }
 
   return (
     <List className={classes.root}>
       {sortedRooms.map((room) => {
-        const displayInfo = getRoomDisplayInfo(room);
-        const isSelected = selectedRoom?.room?._id === room._id;
+        const displayInfo = getRoomDisplayInfo(room)
+        const isSelected = selectedRoom?.room?._id === room._id
 
         return (
           <ListItem
             key={room._id}
-            className={`${classes.listItem} ${isSelected ? classes.selectedItem : ''}`}
+            className={`${classes.listItem} ${
+              isSelected ? classes.selectedItem : ''
+            }`}
             onClick={() => handleRoomClick(room)}
           >
             <ListItemAvatar>
               <Avatar className={classes.avatar}>
-                {displayInfo.avatar && Object.keys(displayInfo.avatar).length > 0 ? (
-                  <AvatarDisplay height={40} width={40} {...displayInfo.avatar} />
+                {displayInfo.avatar &&
+                Object.keys(displayInfo.avatar).length > 0 ? (
+                  <AvatarDisplay
+                    height={40}
+                    width={40}
+                    {...displayInfo.avatar}
+                  />
                 ) : displayInfo.isGroup ? (
                   <GroupIcon style={{ fontSize: 24, color: '#666' }} />
                 ) : displayInfo.name ? (
@@ -268,17 +326,55 @@ const ChatList = ({ search, filterType }) => {
             <ListItemText
               primary={
                 <div className={classes.primaryTextContainer}>
-                  <span className={classes.primaryText}>{displayInfo.name}</span>
+                  <span
+                    className={`${classes.primaryText} ${
+                      displayInfo.linkTo ? classes.nameLink : ''
+                    }`}
+                    onClick={
+                      displayInfo.linkTo
+                        ? (e) => handleNameClick(e, displayInfo.linkTo)
+                        : undefined
+                    }
+                    role={displayInfo.linkTo ? 'link' : undefined}
+                    tabIndex={displayInfo.linkTo ? 0 : undefined}
+                    onKeyDown={
+                      displayInfo.linkTo
+                        ? (e) => {
+                            if (e.key === 'Enter')
+                              handleNameClick(e, displayInfo.linkTo)
+                          }
+                        : undefined
+                    }
+                  >
+                    {displayInfo.name}
+                  </span>
                   <Chip
                     size="small"
-                    icon={room.messageType === 'USER' && room.users?.length === 2 ? <ChatBubbleOutlineIcon /> : <GroupIcon />}
-                    label={room.messageType === 'USER' && room.users?.length === 2 ? 'DM' : 'GROUP'}
-                    className={`${classes.typeChip} ${room.messageType === 'USER' && room.users?.length === 2 ? classes.dmChip : classes.groupChip}`}
+                    icon={
+                      room.messageType === 'USER' &&
+                      room.users?.length === 2 ? (
+                        <ChatBubbleOutlineIcon />
+                      ) : (
+                        <GroupIcon />
+                      )
+                    }
+                    label={
+                      room.messageType === 'USER' && room.users?.length === 2
+                        ? 'DM'
+                        : 'GROUP'
+                    }
+                    className={`${classes.typeChip} ${
+                      room.messageType === 'USER' && room.users?.length === 2
+                        ? classes.dmChip
+                        : classes.groupChip
+                    }`}
                   />
                 </div>
               }
               secondary={
-                <span className={classes.lastMessage}>{displayInfo.subtitle}</span>
+                <span className={classes.lastMessage}>
+                  {displayInfo.subtitle}
+                </span>
               }
             />
             {room.unreadMessages > 0 && (
@@ -287,20 +383,19 @@ const ChatList = ({ search, filterType }) => {
               </div>
             )}
           </ListItem>
-        );
+        )
       })}
     </List>
-  );
-};
+  )
+}
 
 ChatList.propTypes = {
   search: PropTypes.string,
   filterType: PropTypes.oneOf(['chats', 'groups']).isRequired,
-};
+}
 
 ChatList.defaultProps = {
   search: '',
-};
+}
 
-export default ChatList;
-
+export default ChatList

--- a/client/src/components/Chat/ChatList.jsx
+++ b/client/src/components/Chat/ChatList.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
-import { useQuery } from '@apollo/react-hooks'
+import { useQuery, useLazyQuery } from '@apollo/react-hooks'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   makeStyles,
@@ -15,7 +15,7 @@ import {
 import ChatBubbleOutlineIcon from '@material-ui/icons/ChatBubbleOutline'
 import GroupIcon from '@material-ui/icons/Group'
 import { useHistory } from 'react-router-dom'
-import { GET_CHAT_ROOMS, GET_USER } from '../../graphql/query'
+import { GET_CHAT_ROOMS, GET_USER, GET_USER_BY_ID } from '../../graphql/query'
 import { SELECTED_CHAT_ROOM, SET_CHAT_OPEN } from '../../store/chat'
 import LoadingSpinner from '../LoadingSpinner'
 import AvatarDisplay from '../Avatar'
@@ -174,6 +174,10 @@ const ChatList = ({ search, filterType }) => {
   const selectedRoom = useSelector((state) => state.chat.selectedRoom)
   const [userCache, setUserCache] = useState({})
 
+  const [fetchUserById] = useLazyQuery(GET_USER_BY_ID, {
+    fetchPolicy: 'cache-first',
+  })
+
   const { loading, data, refetch } = useQuery(GET_CHAT_ROOMS, {
     fetchPolicy: 'cache-and-network',
     pollInterval: 10000, // Poll every 10 seconds for new messages
@@ -227,14 +231,21 @@ const ChatList = ({ search, filterType }) => {
     dispatch(SELECTED_CHAT_ROOM({ room }))
   }
 
+  const getOtherUserId = (room) => {
+    if (room.messageType !== 'USER' || room.users?.length !== 2) return null
+    const currentUserId = currentUser?._id?.toString()
+    return room.users.find((id) => id?.toString() !== currentUserId)?.toString() || null
+  }
+
   const getRoomDisplayInfo = (room) => {
     if (room.messageType === 'USER' && room.users?.length === 2) {
       // Direct message - use avatar from GraphQL response (resolved by server)
       return {
         name: room.title || 'Direct Message',
-        avatar: room.avatar || null, // Use avatar from room (resolved by messageRoomRelationship)
+        avatar: room.avatar || null,
         subtitle: `${room.users?.length || 0} participants`,
-        linkTo: room.otherUsername ? `/Profile/${room.otherUsername}/` : null,
+        otherUserId: getOtherUserId(room),
+        linkTo: null, // Resolved on-click via user query
       }
     } else if (room.messageType === 'POST') {
       // Group chat for post - show post title
@@ -262,11 +273,28 @@ const ChatList = ({ search, filterType }) => {
     }
   }
 
-  const handleNameClick = (e, linkTo) => {
+  const handleNameClick = async (e, displayInfo) => {
     e.stopPropagation()
-    if (linkTo) {
+    // For posts, navigate directly using the URL
+    if (displayInfo.linkTo) {
       dispatch(SET_CHAT_OPEN(false))
-      history.push(linkTo)
+      history.push(displayInfo.linkTo)
+      return
+    }
+    // For DMs, fetch the other user's username first
+    if (displayInfo.otherUserId) {
+      try {
+        const { data: userData } = await fetchUserById({
+          variables: { user_id: displayInfo.otherUserId },
+        })
+        const username = userData?.user?.username
+        if (username) {
+          dispatch(SET_CHAT_OPEN(false))
+          history.push(`/Profile/${username}/`)
+        }
+      } catch (err) {
+        // Silently fail — user stays on chat
+      }
     }
   }
 
@@ -328,20 +356,30 @@ const ChatList = ({ search, filterType }) => {
                 <div className={classes.primaryTextContainer}>
                   <span
                     className={`${classes.primaryText} ${
-                      displayInfo.linkTo ? classes.nameLink : ''
+                      displayInfo.linkTo || displayInfo.otherUserId
+                        ? classes.nameLink
+                        : ''
                     }`}
                     onClick={
-                      displayInfo.linkTo
-                        ? (e) => handleNameClick(e, displayInfo.linkTo)
+                      displayInfo.linkTo || displayInfo.otherUserId
+                        ? (e) => handleNameClick(e, displayInfo)
                         : undefined
                     }
-                    role={displayInfo.linkTo ? 'link' : undefined}
-                    tabIndex={displayInfo.linkTo ? 0 : undefined}
+                    role={
+                      displayInfo.linkTo || displayInfo.otherUserId
+                        ? 'link'
+                        : undefined
+                    }
+                    tabIndex={
+                      displayInfo.linkTo || displayInfo.otherUserId
+                        ? 0
+                        : undefined
+                    }
                     onKeyDown={
-                      displayInfo.linkTo
+                      displayInfo.linkTo || displayInfo.otherUserId
                         ? (e) => {
                             if (e.key === 'Enter')
-                              handleNameClick(e, displayInfo.linkTo)
+                              handleNameClick(e, displayInfo)
                           }
                         : undefined
                     }

--- a/client/src/components/Chat/MessageBox.jsx
+++ b/client/src/components/Chat/MessageBox.jsx
@@ -17,7 +17,7 @@ import BlockIcon from '@material-ui/icons/Block'
 import RemoveCircleIcon from '@material-ui/icons/RemoveCircle'
 import DeleteIcon from '@material-ui/icons/Delete'
 import { useDispatch, useSelector } from 'react-redux'
-import { useMutation, useQuery } from '@apollo/react-hooks'
+import { useMutation, useQuery, useLazyQuery } from '@apollo/react-hooks'
 import { useHistory } from 'react-router-dom'
 import MessageSend from './MessageSend'
 import MessageItemList from './MessageItemList'
@@ -29,6 +29,7 @@ import {
   GET_CHAT_ROOMS,
   GET_ROOM_MESSAGES,
   GET_ROSTER,
+  GET_USER_BY_ID,
 } from '../../graphql/query'
 import useGuestGuard from '../../utils/useGuestGuard'
 import { useRosterManagement } from '../../hooks/useRosterManagement'
@@ -225,24 +226,9 @@ function Header() {
 
   const history = useHistory()
 
-  // Determine link target for the header
-  const headerLinkTo = (() => {
-    if (!selectedRoom) return null
-    if (messageType === 'USER' && selectedRoom.otherUsername) {
-      return `/Profile/${selectedRoom.otherUsername}/`
-    }
-    if (messageType === 'POST' && selectedRoom.postDetails?.url) {
-      return selectedRoom.postDetails.url
-    }
-    return null
-  })()
-
-  const handleHeaderNavigation = () => {
-    if (headerLinkTo) {
-      dispatch(SET_CHAT_OPEN(false))
-      history.push(headerLinkTo)
-    }
-  }
+  const [fetchUserById] = useLazyQuery(GET_USER_BY_ID, {
+    fetchPolicy: 'cache-first',
+  })
 
   // Get the other user's ID for USER type rooms
   const currentUserIdForHeader = currentUser?._id?.toString()
@@ -260,6 +246,33 @@ function Header() {
           })
           ?.toString() || null
       : null
+
+  // Determine if header is clickable
+  const isHeaderClickable =
+    (messageType === 'USER' && !!otherUserId) ||
+    (messageType === 'POST' && !!selectedRoom?.postDetails?.url)
+
+  const handleHeaderNavigation = async () => {
+    if (messageType === 'POST' && selectedRoom?.postDetails?.url) {
+      dispatch(SET_CHAT_OPEN(false))
+      history.push(selectedRoom.postDetails.url)
+      return
+    }
+    if (messageType === 'USER' && otherUserId) {
+      try {
+        const { data: userData } = await fetchUserById({
+          variables: { user_id: otherUserId },
+        })
+        const username = userData?.user?.username
+        if (username) {
+          dispatch(SET_CHAT_OPEN(false))
+          history.push(`/Profile/${username}/`)
+        }
+      } catch (err) {
+        // Silently fail
+      }
+    }
+  }
 
   // Check if user is blocked
   const isBlocked =
@@ -392,9 +405,9 @@ function Header() {
 
           <Avatar
             className={`${classes.avatar} ${
-              headerLinkTo ? classes.avatarClickable : ''
+              isHeaderClickable ? classes.avatarClickable : ''
             }`}
-            onClick={headerLinkTo ? handleHeaderNavigation : undefined}
+            onClick={isHeaderClickable ? handleHeaderNavigation : undefined}
           >
             {avatar && Object.keys(avatar).length > 0 ? (
               <AvatarDisplay height={40} width={40} {...avatar} />
@@ -410,13 +423,13 @@ function Header() {
           <div className={classes.headerText}>
             <Typography
               className={`${classes.title} ${
-                headerLinkTo ? classes.titleClickable : ''
+                isHeaderClickable ? classes.titleClickable : ''
               }`}
-              onClick={headerLinkTo ? handleHeaderNavigation : undefined}
-              role={headerLinkTo ? 'link' : undefined}
-              tabIndex={headerLinkTo ? 0 : undefined}
+              onClick={isHeaderClickable ? handleHeaderNavigation : undefined}
+              role={isHeaderClickable ? 'link' : undefined}
+              tabIndex={isHeaderClickable ? 0 : undefined}
               onKeyDown={
-                headerLinkTo
+                isHeaderClickable
                   ? (e) => {
                       if (e.key === 'Enter') handleHeaderNavigation()
                     }

--- a/client/src/components/Chat/MessageBox.jsx
+++ b/client/src/components/Chat/MessageBox.jsx
@@ -9,7 +9,7 @@ import {
   MenuItem,
   ListItemIcon,
   ListItemText,
-  Divider
+  Divider,
 } from '@material-ui/core'
 import ArrowBackIcon from '@material-ui/icons/ArrowBack'
 import SettingsIcon from '@material-ui/icons/Settings'
@@ -18,13 +18,18 @@ import RemoveCircleIcon from '@material-ui/icons/RemoveCircle'
 import DeleteIcon from '@material-ui/icons/Delete'
 import { useDispatch, useSelector } from 'react-redux'
 import { useMutation, useQuery } from '@apollo/react-hooks'
+import { useHistory } from 'react-router-dom'
 import MessageSend from './MessageSend'
 import MessageItemList from './MessageItemList'
 import TypingIndicator from './TypingIndicator'
-import { SELECTED_CHAT_ROOM } from '../../store/chat'
+import { SELECTED_CHAT_ROOM, SET_CHAT_OPEN } from '../../store/chat'
 import AvatarDisplay from '../Avatar'
 import { READ_MESSAGES } from '../../graphql/mutations'
-import { GET_CHAT_ROOMS, GET_ROOM_MESSAGES, GET_ROSTER } from '../../graphql/query'
+import {
+  GET_CHAT_ROOMS,
+  GET_ROOM_MESSAGES,
+  GET_ROSTER,
+} from '../../graphql/query'
 import useGuestGuard from '../../utils/useGuestGuard'
 import { useRosterManagement } from '../../hooks/useRosterManagement'
 import { SET_SNACKBAR as SET_UI_SNACKBAR } from '../../store/ui'
@@ -53,17 +58,19 @@ function useWindowSize() {
 
 const useStyles = makeStyles((theme) => ({
   header: {
-    background: theme.palette.mode === 'dark'
-      ? 'linear-gradient(to bottom, #1E2329 0%, #15191E 100%)'
-      : 'linear-gradient(to bottom, #ffffff 0%, #fafbfc 100%)',
+    background:
+      theme.palette.mode === 'dark'
+        ? 'linear-gradient(to bottom, #1E2329 0%, #15191E 100%)'
+        : 'linear-gradient(to bottom, #ffffff 0%, #fafbfc 100%)',
     padding: theme.spacing(1.75, 2),
     borderBottom: `1px solid ${theme.palette.divider}`,
     position: 'sticky',
     top: 0,
     zIndex: 10,
-    boxShadow: theme.palette.mode === 'dark'
-      ? '0 2px 8px rgba(0,0,0,0.3), 0 1px 3px rgba(0,0,0,0.2)'
-      : '0 2px 8px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04)',
+    boxShadow:
+      theme.palette.mode === 'dark'
+        ? '0 2px 8px rgba(0,0,0,0.3), 0 1px 3px rgba(0,0,0,0.2)'
+        : '0 2px 8px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04)',
     backdropFilter: 'blur(10px)',
   },
   headerContent: {
@@ -99,6 +106,20 @@ const useStyles = makeStyles((theme) => ({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     letterSpacing: '-0.01em',
+  },
+  titleClickable: {
+    cursor: 'pointer',
+    '&:hover': {
+      textDecoration: 'underline',
+      color: theme.palette.primary.main,
+    },
+  },
+  avatarClickable: {
+    cursor: 'pointer',
+    '&:hover': {
+      opacity: 0.8,
+      boxShadow: '0 2px 12px rgba(0, 0, 0, 0.2)',
+    },
   },
   subtitle: {
     fontSize: '0.8125rem',
@@ -136,12 +157,14 @@ const useStyles = makeStyles((theme) => ({
     overflow: 'hidden',
     display: 'flex',
     flexDirection: 'column',
-    background: theme.palette.mode === 'dark'
-      ? 'linear-gradient(to bottom, #0B0E11 0%, #15191E 50%, #0B0E11 100%)'
-      : 'linear-gradient(to bottom, #f5f7fa 0%, #ffffff 50%, #f5f7fa 100%)',
-    backgroundImage: theme.palette.mode === 'dark'
-      ? 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(255,255,255,0.01) 2px, rgba(255,255,255,0.01) 4px)'
-      : 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.02) 2px, rgba(0,0,0,0.02) 4px)',
+    background:
+      theme.palette.mode === 'dark'
+        ? 'linear-gradient(to bottom, #0B0E11 0%, #15191E 50%, #0B0E11 100%)'
+        : 'linear-gradient(to bottom, #f5f7fa 0%, #ffffff 50%, #f5f7fa 100%)',
+    backgroundImage:
+      theme.palette.mode === 'dark'
+        ? 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(255,255,255,0.01) 2px, rgba(255,255,255,0.01) 4px)'
+        : 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.02) 2px, rgba(0,0,0,0.02) 4px)',
     position: 'relative',
   },
   messagesContainer: {
@@ -157,25 +180,33 @@ const useStyles = makeStyles((theme) => ({
       background: 'transparent',
     },
     '&::-webkit-scrollbar-thumb': {
-      background: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.2)' : theme.palette.grey[400],
+      background:
+        theme.palette.mode === 'dark'
+          ? 'rgba(255,255,255,0.2)'
+          : theme.palette.grey[400],
       borderRadius: 4,
       border: '2px solid transparent',
       backgroundClip: 'padding-box',
       '&:hover': {
-        background: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.3)' : theme.palette.grey[500],
+        background:
+          theme.palette.mode === 'dark'
+            ? 'rgba(255,255,255,0.3)'
+            : theme.palette.grey[500],
         backgroundClip: 'padding-box',
       },
     },
   },
   footer: {
-    background: theme.palette.mode === 'dark'
-      ? 'linear-gradient(to top, #1E2329 0%, #15191E 100%)'
-      : 'linear-gradient(to top, #ffffff 0%, #fafbfc 100%)',
+    background:
+      theme.palette.mode === 'dark'
+        ? 'linear-gradient(to top, #1E2329 0%, #15191E 100%)'
+        : 'linear-gradient(to top, #ffffff 0%, #fafbfc 100%)',
     borderTop: `1px solid ${theme.palette.divider}`,
     padding: theme.spacing(1.75, 2),
-    boxShadow: theme.palette.mode === 'dark'
-      ? '0 -2px 12px rgba(0, 0, 0, 0.3), 0 -1px 4px rgba(0, 0, 0, 0.2)'
-      : '0 -2px 12px rgba(0, 0, 0, 0.06), 0 -1px 4px rgba(0, 0, 0, 0.04)',
+    boxShadow:
+      theme.palette.mode === 'dark'
+        ? '0 -2px 12px rgba(0, 0, 0, 0.3), 0 -1px 4px rgba(0, 0, 0, 0.2)'
+        : '0 -2px 12px rgba(0, 0, 0, 0.06), 0 -1px 4px rgba(0, 0, 0, 0.04)',
   },
 }))
 
@@ -189,32 +220,65 @@ function Header() {
   const { refetch: refetchChatRooms } = useQuery(GET_CHAT_ROOMS, { skip: true })
   const { data: rosterData } = useQuery(GET_ROSTER, { skip: !currentUser })
 
-  const { title, avatar, messageType, users, _id: messageRoomId } = selectedRoom || {}
+  const { title, avatar, messageType, users, _id: messageRoomId } =
+    selectedRoom || {}
+
+  const history = useHistory()
+
+  // Determine link target for the header
+  const headerLinkTo = (() => {
+    if (!selectedRoom) return null
+    if (messageType === 'USER' && selectedRoom.otherUsername) {
+      return `/Profile/${selectedRoom.otherUsername}/`
+    }
+    if (messageType === 'POST' && selectedRoom.postDetails?.url) {
+      return selectedRoom.postDetails.url
+    }
+    return null
+  })()
+
+  const handleHeaderNavigation = () => {
+    if (headerLinkTo) {
+      dispatch(SET_CHAT_OPEN(false))
+      history.push(headerLinkTo)
+    }
+  }
 
   // Get the other user's ID for USER type rooms
   const currentUserIdForHeader = currentUser?._id?.toString()
-  const otherUserId = messageType === 'USER' && users?.length === 2
-    ? users.find((id) => {
-      if (!id || !currentUserIdForHeader) return false
-      try {
-        return id.toString() !== currentUserIdForHeader
-      } catch (e) {
-        console.warn('Error comparing user IDs in header:', e)
-        return false
-      }
-    })?.toString() || null
-    : null
+  const otherUserId =
+    messageType === 'USER' && users?.length === 2
+      ? users
+          .find((id) => {
+            if (!id || !currentUserIdForHeader) return false
+            try {
+              return id.toString() !== currentUserIdForHeader
+            } catch (e) {
+              console.warn('Error comparing user IDs in header:', e)
+              return false
+            }
+          })
+          ?.toString() || null
+      : null
 
   // Check if user is blocked
-  const isBlocked = otherUserId && rosterData?.getRoster?.some((r) => {
-    const rUserId = r.userId?.toString()
-    const rBuddyId = r.buddyId?.toString()
-    const currentUserId = currentUser?._id?.toString()
-    const otherId = otherUserId.toString()
+  const isBlocked =
+    otherUserId &&
+    rosterData?.getRoster?.some((r) => {
+      const rUserId = r.userId?.toString()
+      const rBuddyId = r.buddyId?.toString()
+      const currentUserId = currentUser?._id?.toString()
+      const otherId = otherUserId.toString()
 
-    return (rUserId === currentUserId && rBuddyId === otherId && r.status === 'blocked') ||
-      (rUserId === otherId && rBuddyId === currentUserId && r.status === 'blocked')
-  })
+      return (
+        (rUserId === currentUserId &&
+          rBuddyId === otherId &&
+          r.status === 'blocked') ||
+        (rUserId === otherId &&
+          rBuddyId === currentUserId &&
+          r.status === 'blocked')
+      )
+    })
 
   const handleBack = () => {
     dispatch(SELECTED_CHAT_ROOM(null))
@@ -236,30 +300,39 @@ function Header() {
         await unblockBuddy(otherUserId)
         // Refetch chat rooms to update the list (chat will reappear after unblocking)
         await refetchChatRooms()
-        dispatch(SET_UI_SNACKBAR({
-          open: true,
-          message: 'User unblocked successfully',
-          type: 'success',
-        }))
+        dispatch(
+          SET_UI_SNACKBAR({
+            open: true,
+            message: 'User unblocked successfully',
+            type: 'success',
+          }),
+        )
       } else {
         await blockBuddy(otherUserId)
         // Refetch chat rooms to update the list (chat remains visible for both users)
         await refetchChatRooms()
-        dispatch(SET_UI_SNACKBAR({
-          open: true,
-          message: 'User blocked successfully. Chat history is preserved, but they cannot send new messages.',
-          type: 'success',
-        }))
+        dispatch(
+          SET_UI_SNACKBAR({
+            open: true,
+            message:
+              'User blocked successfully. Chat history is preserved, but they cannot send new messages.',
+            type: 'success',
+          }),
+        )
         // Keep chat open so both users can see their chat history
         // Only close the menu
       }
       handleMenuClose()
     } catch (error) {
-      dispatch(SET_UI_SNACKBAR({
-        open: true,
-        message: error.message || `Failed to ${isBlocked ? 'unblock' : 'block'} user`,
-        type: 'danger',
-      }))
+      dispatch(
+        SET_UI_SNACKBAR({
+          open: true,
+          message:
+            error.message ||
+            `Failed to ${isBlocked ? 'unblock' : 'block'} user`,
+          type: 'danger',
+        }),
+      )
     }
   }
 
@@ -270,18 +343,22 @@ function Header() {
       await removeBuddy(otherUserId)
       // Refetch chat rooms to update the list
       await refetchChatRooms()
-      dispatch(SET_UI_SNACKBAR({
-        open: true,
-        message: 'Buddy removed successfully',
-        type: 'success',
-      }))
+      dispatch(
+        SET_UI_SNACKBAR({
+          open: true,
+          message: 'Buddy removed successfully',
+          type: 'success',
+        }),
+      )
       handleMenuClose()
     } catch (error) {
-      dispatch(SET_UI_SNACKBAR({
-        open: true,
-        message: error.message || 'Failed to remove buddy',
-        type: 'danger',
-      }))
+      dispatch(
+        SET_UI_SNACKBAR({
+          open: true,
+          message: error.message || 'Failed to remove buddy',
+          type: 'danger',
+        }),
+      )
     }
   }
 
@@ -289,11 +366,13 @@ function Header() {
     // For now, just close the chat
     // In the future, this could archive or delete the chat room
     dispatch(SELECTED_CHAT_ROOM(null))
-    dispatch(SET_UI_SNACKBAR({
-      open: true,
-      message: 'Chat closed',
-      type: 'info',
-    }))
+    dispatch(
+      SET_UI_SNACKBAR({
+        open: true,
+        message: 'Chat closed',
+        type: 'info',
+      }),
+    )
     handleMenuClose()
   }
 
@@ -303,11 +382,20 @@ function Header() {
     <Fade in timeout={300}>
       <div className={classes.header}>
         <div className={classes.headerContent}>
-          <IconButton onClick={handleBack} className={classes.backButton} size="small">
+          <IconButton
+            onClick={handleBack}
+            className={classes.backButton}
+            size="small"
+          >
             <ArrowBackIcon fontSize="small" />
           </IconButton>
 
-          <Avatar className={classes.avatar}>
+          <Avatar
+            className={`${classes.avatar} ${
+              headerLinkTo ? classes.avatarClickable : ''
+            }`}
+            onClick={headerLinkTo ? handleHeaderNavigation : undefined}
+          >
             {avatar && Object.keys(avatar).length > 0 ? (
               <AvatarDisplay height={40} width={40} {...avatar} />
             ) : messageType === 'USER' && title ? (
@@ -320,7 +408,21 @@ function Header() {
           </Avatar>
 
           <div className={classes.headerText}>
-            <Typography className={classes.title}>
+            <Typography
+              className={`${classes.title} ${
+                headerLinkTo ? classes.titleClickable : ''
+              }`}
+              onClick={headerLinkTo ? handleHeaderNavigation : undefined}
+              role={headerLinkTo ? 'link' : undefined}
+              tabIndex={headerLinkTo ? 0 : undefined}
+              onKeyDown={
+                headerLinkTo
+                  ? (e) => {
+                      if (e.key === 'Enter') handleHeaderNavigation()
+                    }
+                  : undefined
+              }
+            >
               {title || 'Chat'}
             </Typography>
             <Typography className={classes.subtitle}>
@@ -358,29 +460,33 @@ function Header() {
               },
             }}
           >
-            {messageType === 'USER' && otherUserId ? [
-              <MenuItem
-                key="block"
-                onClick={handleBlockUser}
-                className={`${classes.menuItem} ${classes.menuItemDanger}`}
-              >
-                <ListItemIcon className={classes.menuItemIcon}>
-                  <BlockIcon fontSize="small" />
-                </ListItemIcon>
-                <ListItemText primary={isBlocked ? 'Unblock User' : 'Block User'} />
-              </MenuItem>,
-              <MenuItem
-                key="remove"
-                onClick={handleRemoveBuddy}
-                className={`${classes.menuItem} ${classes.menuItemDanger}`}
-              >
-                <ListItemIcon className={classes.menuItemIcon}>
-                  <RemoveCircleIcon fontSize="small" />
-                </ListItemIcon>
-                <ListItemText primary="Remove Buddy" />
-              </MenuItem>,
-              <Divider key="divider" />
-            ] : null}
+            {messageType === 'USER' && otherUserId
+              ? [
+                  <MenuItem
+                    key="block"
+                    onClick={handleBlockUser}
+                    className={`${classes.menuItem} ${classes.menuItemDanger}`}
+                  >
+                    <ListItemIcon className={classes.menuItemIcon}>
+                      <BlockIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={isBlocked ? 'Unblock User' : 'Block User'}
+                    />
+                  </MenuItem>,
+                  <MenuItem
+                    key="remove"
+                    onClick={handleRemoveBuddy}
+                    className={`${classes.menuItem} ${classes.menuItemDanger}`}
+                  >
+                    <ListItemIcon className={classes.menuItemIcon}>
+                      <RemoveCircleIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Remove Buddy" />
+                  </MenuItem>,
+                  <Divider key="divider" />,
+                ]
+              : null}
             <MenuItem
               onClick={handleDeleteChat}
               className={`${classes.menuItem} ${classes.menuItemDanger}`}
@@ -427,22 +533,25 @@ function MessageBox() {
     )
   }
 
-  const { _id: messageRoomId, title, messageType, users } = selectedRoomData || {}
+  const { _id: messageRoomId, title, messageType, users } =
+    selectedRoomData || {}
 
   // Get the other user's ID for DM creation if room doesn't exist yet
   const currentUser = useSelector((state) => state.user?.data)
   const currentUserId = currentUser?._id?.toString()
   const componentId = messageRoomId
     ? null
-    : users?.find((id) => {
-      if (!id || !currentUserId) return false
-      try {
-        return id.toString() !== currentUserId
-      } catch (e) {
-        console.warn('Error comparing user IDs:', e)
-        return false
-      }
-    })?.toString() || null
+    : users
+        ?.find((id) => {
+          if (!id || !currentUserId) return false
+          try {
+            return id.toString() !== currentUserId
+          } catch (e) {
+            console.warn('Error comparing user IDs:', e)
+            return false
+          }
+        })
+        ?.toString() || null
 
   // Helper function to safely extract error message as a string
   // This function never returns objects or null - only safe strings
@@ -468,7 +577,12 @@ function MessageBox() {
       if (Object.prototype.hasOwnProperty.call(err, 'message')) {
         const msg = err.message
         // Check if msg is not null/undefined and is a string
-        if (msg !== null && msg !== undefined && typeof msg === 'string' && msg.length > 0) {
+        if (
+          msg !== null &&
+          msg !== undefined &&
+          typeof msg === 'string' &&
+          msg.length > 0
+        ) {
           message = msg
         }
       }
@@ -487,7 +601,12 @@ function MessageBox() {
           if (firstErr !== null && firstErr !== undefined) {
             if (Object.prototype.hasOwnProperty.call(firstErr, 'message')) {
               const msg = firstErr.message
-              if (msg !== null && msg !== undefined && typeof msg === 'string' && msg.length > 0) {
+              if (
+                msg !== null &&
+                msg !== undefined &&
+                typeof msg === 'string' &&
+                msg.length > 0
+              ) {
                 return msg
               }
             }
@@ -508,7 +627,12 @@ function MessageBox() {
           }
           if (Object.prototype.hasOwnProperty.call(netErr, 'message')) {
             const msg = netErr.message
-            if (msg !== null && msg !== undefined && typeof msg === 'string' && msg.length > 0) {
+            if (
+              msg !== null &&
+              msg !== undefined &&
+              typeof msg === 'string' &&
+              msg.length > 0
+            ) {
               return msg
             }
           }
@@ -530,7 +654,12 @@ function MessageBox() {
   // Refetch chat rooms to get updated room data (especially when room doesn't exist yet)
   // Start without polling, we'll control it manually
   // Note: Error handling is suppressed to prevent crashes from Apollo Client's error object serialization
-  const { data: roomsData, error: roomsError, stopPolling, startPolling } = useQuery(GET_CHAT_ROOMS, {
+  const {
+    data: roomsData,
+    error: roomsError,
+    stopPolling,
+    startPolling,
+  } = useQuery(GET_CHAT_ROOMS, {
     fetchPolicy: 'cache-and-network',
     pollInterval: 0, // Start with no polling - we'll control it manually
     errorPolicy: 'all', // Continue to show cached data even if there's an error
@@ -542,7 +671,7 @@ function MessageBox() {
   useEffect(() => {
     if (roomsError) {
       // Silently increment error count without trying to access error properties
-      setErrorRetryCount(prev => {
+      setErrorRetryCount((prev) => {
         const newCount = prev + 1
         if (newCount >= MAX_ERROR_RETRIES) {
           setShouldPoll(false)
@@ -606,7 +735,8 @@ function MessageBox() {
     if (!messageRoomId && roomsData?.messageRooms && selectedRoomData?.users) {
       // Find the room that matches our users
       const matchingRoom = roomsData.messageRooms.find((room) => {
-        if (room.messageType !== 'USER' || room.users?.length !== 2) return false
+        if (room.messageType !== 'USER' || room.users?.length !== 2)
+          return false
         try {
           const roomUserIds = room.users
             .map((id) => {
@@ -632,7 +762,8 @@ function MessageBox() {
             })
             .filter(Boolean)
 
-          if (roomUserIds.length !== 2 || selectedUserIds.length !== 2) return false
+          if (roomUserIds.length !== 2 || selectedUserIds.length !== 2)
+            return false
           return (
             roomUserIds.includes(selectedUserIds[0]) &&
             roomUserIds.includes(selectedUserIds[1])

--- a/client/src/components/Chat/MessageItem.jsx
+++ b/client/src/components/Chat/MessageItem.jsx
@@ -1,12 +1,20 @@
-import { Avatar, Paper, IconButton, Tooltip, Typography } from '@material-ui/core'
+import {
+  Avatar,
+  Paper,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@material-ui/core'
 import { Delete, Done, DoneAll } from '@material-ui/icons'
 import { makeStyles } from '@material-ui/core/styles'
 import PropTypes from 'prop-types'
 import { useSelector, useDispatch } from 'react-redux'
 import { useMutation } from '@apollo/react-hooks'
+import { useHistory } from 'react-router-dom'
 import AvatarDisplay from '../Avatar'
 import { DELETE_MESSAGE } from '../../graphql/mutations'
 import { SET_SNACKBAR } from '../../store/ui'
+import { SET_CHAT_OPEN } from '../../store/chat'
 
 const useStyles = makeStyles((theme) => ({
   messageWrapper: {
@@ -33,9 +41,10 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: theme.spacing(1.25),
     flexShrink: 0,
     border: `2px solid ${theme.palette.background.paper}`,
-    boxShadow: theme.palette.mode === 'dark'
-      ? '0 2px 8px rgba(0, 0, 0, 0.3)'
-      : '0 2px 8px rgba(0, 0, 0, 0.1)',
+    boxShadow:
+      theme.palette.mode === 'dark'
+        ? '0 2px 8px rgba(0, 0, 0, 0.3)'
+        : '0 2px 8px rgba(0, 0, 0, 0.1)',
   },
   avatarOwn: {
     order: 2,
@@ -54,21 +63,24 @@ const useStyles = makeStyles((theme) => ({
     background: theme.palette.mode === 'dark' ? '#2A2A2A' : '#ffffff',
     borderRadius: '20px 20px 20px 6px',
     padding: theme.spacing(1.25, 1.75),
-    boxShadow: theme.palette.mode === 'dark'
-      ? '0 2px 8px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2)'
-      : '0 2px 8px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08)',
+    boxShadow:
+      theme.palette.mode === 'dark'
+        ? '0 2px 8px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2)'
+        : '0 2px 8px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08)',
     wordWrap: 'break-word',
     fontSize: '0.9375rem',
     lineHeight: 1.5,
     color: theme.palette.text.primary,
-    border: theme.palette.mode === 'dark'
-      ? `1px solid ${theme.palette.divider}`
-      : `1px solid ${theme.palette.grey[200]}`,
+    border:
+      theme.palette.mode === 'dark'
+        ? `1px solid ${theme.palette.divider}`
+        : `1px solid ${theme.palette.grey[200]}`,
     transition: 'all 0.2s ease',
     '&:hover': {
-      boxShadow: theme.palette.mode === 'dark'
-        ? '0 4px 12px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.2)'
-        : '0 4px 12px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.1)',
+      boxShadow:
+        theme.palette.mode === 'dark'
+          ? '0 4px 12px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.2)'
+          : '0 4px 12px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.1)',
     },
   },
   bubbleReverse: {
@@ -76,7 +88,8 @@ const useStyles = makeStyles((theme) => ({
     background: 'linear-gradient(135deg, #52b274 0%, #4a9e63 100%)',
     borderRadius: '20px 20px 6px 20px',
     padding: theme.spacing(1.25, 1.75),
-    boxShadow: '0 4px 12px rgba(82, 178, 116, 0.35), 0 2px 4px rgba(82, 178, 116, 0.2)',
+    boxShadow:
+      '0 4px 12px rgba(82, 178, 116, 0.35), 0 2px 4px rgba(82, 178, 116, 0.2)',
     wordWrap: 'break-word',
     fontSize: '0.9375rem',
     lineHeight: 1.5,
@@ -84,7 +97,8 @@ const useStyles = makeStyles((theme) => ({
     border: 'none',
     transition: 'all 0.2s ease',
     '&:hover': {
-      boxShadow: '0 6px 16px rgba(82, 178, 116, 0.4), 0 3px 6px rgba(82, 178, 116, 0.25)',
+      boxShadow:
+        '0 6px 16px rgba(82, 178, 116, 0.4), 0 3px 6px rgba(82, 178, 116, 0.25)',
     },
   },
   deleteIcon: {
@@ -104,18 +118,20 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.mode === 'dark' ? '#3A3A3A' : '#ffffff',
     borderRadius: '50%',
     padding: '6px',
-    boxShadow: theme.palette.mode === 'dark'
-      ? '0 3px 10px rgba(0,0,0,0.4)'
-      : '0 3px 10px rgba(0,0,0,0.2)',
+    boxShadow:
+      theme.palette.mode === 'dark'
+        ? '0 3px 10px rgba(0,0,0,0.4)'
+        : '0 3px 10px rgba(0,0,0,0.2)',
     width: 28,
     height: 28,
     opacity: 0,
     transition: 'opacity 0.2s ease',
     '&:hover': {
       backgroundColor: theme.palette.mode === 'dark' ? '#4A4A4A' : '#f5f5f5',
-      boxShadow: theme.palette.mode === 'dark'
-        ? '0 4px 14px rgba(0,0,0,0.5)'
-        : '0 4px 14px rgba(0,0,0,0.25)',
+      boxShadow:
+        theme.palette.mode === 'dark'
+          ? '0 4px 14px rgba(0,0,0,0.5)'
+          : '0 4px 14px rgba(0,0,0,0.25)',
       transform: 'scale(1.1)',
     },
   },
@@ -149,24 +165,36 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: 'bold',
   },
   receiptIconSent: {
-    color: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.6)' : 'rgba(0, 0, 0, 0.6)',
+    color:
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, 0.6)'
+        : 'rgba(0, 0, 0, 0.6)',
     opacity: 1,
     fontSize: '1rem',
   },
   receiptIconSentOther: {
-    color: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.5)',
+    color:
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, 0.5)'
+        : 'rgba(0, 0, 0, 0.5)',
     opacity: 1,
   },
   timestamp: {
     fontSize: '0.6875rem',
-    color: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.65)' : 'rgba(0, 0, 0, 0.65)',
+    color:
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, 0.65)'
+        : 'rgba(0, 0, 0, 0.65)',
     marginTop: theme.spacing(0.25),
     paddingLeft: theme.spacing(0.5),
     fontWeight: 500,
   },
   timestampOwn: {
     fontSize: '0.6875rem',
-    color: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.65)' : 'rgba(0, 0, 0, 0.65)',
+    color:
+      theme.palette.mode === 'dark'
+        ? 'rgba(255, 255, 255, 0.65)'
+        : 'rgba(0, 0, 0, 0.65)',
     marginTop: theme.spacing(0.25),
     paddingRight: theme.spacing(0.5),
     textAlign: 'right',
@@ -179,11 +207,26 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: theme.spacing(0.25),
     paddingLeft: theme.spacing(0.5),
   },
+  clickableAvatar: {
+    cursor: 'pointer',
+    '&:hover': {
+      opacity: 0.8,
+      boxShadow: '0 2px 12px rgba(0, 0, 0, 0.2)',
+    },
+  },
+  clickableName: {
+    cursor: 'pointer',
+    '&:hover': {
+      textDecoration: 'underline',
+      color: theme.palette.primary.main,
+    },
+  },
 }))
 
 function MessageItem({ message }) {
   const classes = useStyles()
   const dispatch = useDispatch()
+  const history = useHistory()
   const user = useSelector((state) => state.user?.data)
   const selectedRoom = useSelector((state) => state.chat?.selectedRoom?.room)
 
@@ -196,14 +239,19 @@ function MessageItem({ message }) {
   // Get other user ID for DM read receipt check
   const getOtherUserId = () => {
     if (!selectedRoom || !selectedRoom.users) return null
-    const otherUser = selectedRoom.users.find((id) => id.toString() !== userId.toString())
+    const otherUser = selectedRoom.users.find(
+      (id) => id.toString() !== userId.toString(),
+    )
     return otherUser?.toString()
   }
 
   const [deleteMessage] = useMutation(DELETE_MESSAGE, {
     update(cache, { data: { deleteMessage } }) {
       if (deleteMessage && deleteMessage._id) {
-        const normalizedId = cache.identify({ __typename: 'Message', _id: deleteMessage._id })
+        const normalizedId = cache.identify({
+          __typename: 'Message',
+          _id: deleteMessage._id,
+        })
         cache.evict({ id: normalizedId })
         cache.gc()
       }
@@ -246,9 +294,10 @@ function MessageItem({ message }) {
 
   // For DMs: check if the recipient (other user) has read it
   // For groups: check if anyone has read it
-  const isRead = selectedRoom?.messageType === 'USER' && normalizedOtherUserId
-    ? normalizedReadBy.includes(normalizedOtherUserId)
-    : normalizedReadBy.length > 0
+  const isRead =
+    selectedRoom?.messageType === 'USER' && normalizedOtherUserId
+      ? normalizedReadBy.includes(normalizedOtherUserId)
+      : normalizedReadBy.length > 0
 
   // Format timestamp
   const formatTime = (date) => {
@@ -263,7 +312,12 @@ function MessageItem({ message }) {
     if (d.toDateString() === now.toDateString()) {
       return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
     }
-    return d.toLocaleDateString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+    return d.toLocaleDateString([], {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
   }
 
   // Get read receipt icon with better styling
@@ -291,22 +345,54 @@ function MessageItem({ message }) {
   }
 
   return (
-    <div className={`${classes.messageWrapper} ${isDefaultDirection ? classes.messageWrapperOther : classes.messageWrapperOwn}`}>
+    <div
+      className={`${classes.messageWrapper} ${
+        isDefaultDirection
+          ? classes.messageWrapperOther
+          : classes.messageWrapperOwn
+      }`}
+    >
       {isDefaultDirection && (
-        <Avatar className={classes.avatar}>
+        <Avatar
+          className={`${classes.avatar} ${
+            message.user?.username ? classes.clickableAvatar : ''
+          }`}
+          onClick={
+            message.user?.username
+              ? () => {
+                  dispatch(SET_CHAT_OPEN(false))
+                  history.push(`/Profile/${message.user.username}/`)
+                }
+              : undefined
+          }
+        >
           <AvatarDisplay height={40} width={40} {...message.user.avatar} />
         </Avatar>
       )}
       <div className={classes.bubbleContainer}>
         {isDefaultDirection && message.user?.name && (
-          <Typography className={classes.senderName}>
+          <Typography
+            className={`${classes.senderName} ${
+              message.user?.username ? classes.clickableName : ''
+            }`}
+            onClick={
+              message.user?.username
+                ? () => {
+                    dispatch(SET_CHAT_OPEN(false))
+                    history.push(`/Profile/${message.user.username}/`)
+                  }
+                : undefined
+            }
+          >
             {message.user.name || message.user.username}
           </Typography>
         )}
         <div className={classes.messageContainer}>
           <Paper
             elevation={0}
-            className={isDefaultDirection ? classes.bubble : classes.bubbleReverse}
+            className={
+              isDefaultDirection ? classes.bubble : classes.bubbleReverse
+            }
           >
             <Typography
               variant="body2"
@@ -331,7 +417,14 @@ function MessageItem({ message }) {
             </IconButton>
           )}
         </div>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: isOwnMessage ? 'flex-end' : 'flex-start', gap: 6 }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: isOwnMessage ? 'flex-end' : 'flex-start',
+            gap: 6,
+          }}
+        >
           {isOwnMessage && getReadReceiptIcon()}
           <Typography
             className={isOwnMessage ? classes.timestampOwn : classes.timestamp}
@@ -356,7 +449,10 @@ MessageItem.propTypes = {
     userId: PropTypes.string.isRequired,
     user: PropTypes.object,
     readBy: PropTypes.array,
-    created: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
+    created: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.instanceOf(Date),
+    ]),
   }).isRequired,
 }
 

--- a/client/src/graphql/query.jsx
+++ b/client/src/graphql/query.jsx
@@ -165,6 +165,7 @@ export const GET_CHAT_ROOMS = gql`
       lastActivity
       lastMessageTime
       title
+      otherUsername
       avatar
       unreadMessages
       postId
@@ -603,13 +604,13 @@ export const GET_USER_ACTIVITY = gql`
           }
           bookmarkedBy
           created
-                  creator {
-          _id
-          name
-          username
-          avatar
-          contributorBadge
-        }
+          creator {
+            _id
+            name
+            username
+            avatar
+            contributorBadge
+          }
         }
         voteId
         vote {
@@ -703,7 +704,7 @@ export const GET_LATEST_QUOTES = gql`
     }
   }
 `
-export const GET_FEATURED_POSTS = gql` 
+export const GET_FEATURED_POSTS = gql`
   query featuredPosts(
     $limit: Int
     $offset: Int

--- a/client/src/graphql/query.jsx
+++ b/client/src/graphql/query.jsx
@@ -165,7 +165,6 @@ export const GET_CHAT_ROOMS = gql`
       lastActivity
       lastMessageTime
       title
-      otherUsername
       avatar
       unreadMessages
       postId
@@ -176,6 +175,15 @@ export const GET_CHAT_ROOMS = gql`
         userId
         url
       }
+    }
+  }
+`
+
+export const GET_USER_BY_ID = gql`
+  query userById($user_id: String!) {
+    user(user_id: $user_id) {
+      _id
+      username
     }
   }
 `

--- a/server/app/data/resolvers/relationship/message_room_relationship.js
+++ b/server/app/data/resolvers/relationship/message_room_relationship.js
@@ -113,22 +113,6 @@ export const messageRoomRelationship = () => {
 
       return avatar || null
     },
-    async otherUsername(data, root, context) {
-      const { users, messageType } = data
-      if (messageType !== 'USER') return null
-      const contextUserId = context.user._id
-      const userBuddy = users.filter(
-        (user) => user.toString() !== contextUserId.toString(),
-      )
-      if (userBuddy.length === 0) userBuddy.push(contextUserId)
-      try {
-        const buddyUserId = new ObjectId(userBuddy[0])
-        const user = await UserModel.findById(buddyUserId)
-        return user?.username || null
-      } catch (error) {
-        return null
-      }
-    },
     async messages(data, root, context) {
       const { _id: messageRoomId } = data
       const messages = await getMessages(messageRoomId, context)

--- a/server/app/data/resolvers/relationship/message_room_relationship.js
+++ b/server/app/data/resolvers/relationship/message_room_relationship.js
@@ -1,122 +1,143 @@
-import { ObjectId } from 'mongodb';
-import MessageModel from '../models/MessageModel';
-import UserModel from '../models/UserModel';
-import PostModel from '../models/PostModel';
-import { getUnreadMessages } from '~/resolvers/utils/message/getUnreadMessages';
-import { getMessages } from '../utils/message/getMessages';
+import { ObjectId } from 'mongodb'
+import MessageModel from '../models/MessageModel'
+import UserModel from '../models/UserModel'
+import PostModel from '../models/PostModel'
+import { getUnreadMessages } from '~/resolvers/utils/message/getUnreadMessages'
+import { getMessages } from '../utils/message/getMessages'
 
 export const messageRoomRelationship = () => {
   return {
     async title(data, root, context) {
-      const { users, messageType, postId } = data;
-      let title;
+      const { users, messageType, postId } = data
+      let title
       if (messageType === 'USER') {
-        const contextUserId = context.user._id;
+        const contextUserId = context.user._id
 
-        const userBuddy = users.filter((user) => user.toString() !== contextUserId.toString());
+        const userBuddy = users.filter(
+          (user) => user.toString() !== contextUserId.toString(),
+        )
 
         if (userBuddy) {
           if (userBuddy.length === 0) {
-            userBuddy.push(contextUserId);
+            userBuddy.push(contextUserId)
           }
-          const buddyUserId = new ObjectId(userBuddy[0]);
-          const user = await UserModel.findById(buddyUserId);
-          title = user.name;
+          const buddyUserId = new ObjectId(userBuddy[0])
+          const user = await UserModel.findById(buddyUserId)
+          title = user.name
           if (!title) {
-            title = user.username;
+            title = user.username
           }
           if (!title) {
-            title = 'Unknown User';
+            title = 'Unknown User'
           }
         }
       } else if (messageType === 'POST') {
-        const postIdObject = new ObjectId(postId);
-        const post = await PostModel.findById(postIdObject);
+        const postIdObject = new ObjectId(postId)
+        const post = await PostModel.findById(postIdObject)
         if (post) {
-          title = post.title;
+          title = post.title
         }
       }
 
       if (!title) {
-        const messageRoomId = new ObjectId(data.messageRoomId);
-        const message = await MessageModel.findOne({ messageRoomId });
-        title = message.title;
+        const messageRoomId = new ObjectId(data.messageRoomId)
+        const message = await MessageModel.findOne({ messageRoomId })
+        title = message.title
       }
-      return title;
+      return title
     },
     async avatar(data, root, context) {
-      const { users, messageType, postId } = data;
-      let avatar;
-      
+      const { users, messageType, postId } = data
+      let avatar
+
       if (messageType === 'USER') {
         // Direct message - return the other user's avatar
         if (context.user && context.user._id) {
-          const contextUserId = context.user._id;
-          const userBuddy = users.filter((user) => user.toString() !== contextUserId.toString());
+          const contextUserId = context.user._id
+          const userBuddy = users.filter(
+            (user) => user.toString() !== contextUserId.toString(),
+          )
           if (userBuddy && userBuddy.length > 0) {
-            const buddyUserId = new ObjectId(userBuddy[0]);
-            const user = await UserModel.findById(buddyUserId);
+            const buddyUserId = new ObjectId(userBuddy[0])
+            const user = await UserModel.findById(buddyUserId)
             if (user && user.avatar) {
-              avatar = user.avatar;
+              avatar = user.avatar
             }
           }
         } else if (users && users.length > 0) {
           // If no context user, return first user's avatar
-          const userId = new ObjectId(users[0]);
-          const user = await UserModel.findById(userId);
+          const userId = new ObjectId(users[0])
+          const user = await UserModel.findById(userId)
           if (user && user.avatar) {
-            avatar = user.avatar;
+            avatar = user.avatar
           }
         }
       } else if (messageType === 'POST' && postId) {
         // Group chat for post - return the post creator's avatar
         try {
-          const postIdObject = new ObjectId(postId);
-          const post = await PostModel.findById(postIdObject);
+          const postIdObject = new ObjectId(postId)
+          const post = await PostModel.findById(postIdObject)
           if (post && post.userId) {
-            const postCreator = await UserModel.findById(post.userId);
+            const postCreator = await UserModel.findById(post.userId)
             if (postCreator && postCreator.avatar) {
-              avatar = postCreator.avatar;
+              avatar = postCreator.avatar
             }
           }
         } catch (error) {
           // If post not found, fall through to group chat logic
         }
       }
-      
+
       // For other group chats or if avatar not found above, return first user's avatar (excluding current user)
       if (!avatar && users && users.length > 0) {
         try {
-          const contextUserId = context.user?._id;
+          const contextUserId = context.user?._id
           // Get first user that's not the current user, or first user if no context user
-          const otherUser = users.find((user) => {
-            if (!contextUserId) return true;
-            return user.toString() !== contextUserId.toString();
-          }) || users[0];
-          
+          const otherUser =
+            users.find((user) => {
+              if (!contextUserId) return true
+              return user.toString() !== contextUserId.toString()
+            }) || users[0]
+
           if (otherUser) {
-            const userId = new ObjectId(otherUser);
-            const user = await UserModel.findById(userId);
+            const userId = new ObjectId(otherUser)
+            const user = await UserModel.findById(userId)
             if (user && user.avatar) {
-              avatar = user.avatar;
+              avatar = user.avatar
             }
           }
         } catch (error) {
           // If user not found, return null
         }
       }
-      
-      return avatar || null;
+
+      return avatar || null
+    },
+    async otherUsername(data, root, context) {
+      const { users, messageType } = data
+      if (messageType !== 'USER') return null
+      const contextUserId = context.user._id
+      const userBuddy = users.filter(
+        (user) => user.toString() !== contextUserId.toString(),
+      )
+      if (userBuddy.length === 0) userBuddy.push(contextUserId)
+      try {
+        const buddyUserId = new ObjectId(userBuddy[0])
+        const user = await UserModel.findById(buddyUserId)
+        return user?.username || null
+      } catch (error) {
+        return null
+      }
     },
     async messages(data, root, context) {
-      const { _id: messageRoomId } = data;
-      const messages = await getMessages(messageRoomId, context);
-      return messages;
+      const { _id: messageRoomId } = data
+      const messages = await getMessages(messageRoomId, context)
+      return messages
     },
     async unreadMessages(data, root, context) {
-      const { _id: messageRoomId } = data;
-      const unreadMessages = await getUnreadMessages(messageRoomId, context);
-      return unreadMessages.length;
+      const { _id: messageRoomId } = data
+      const unreadMessages = await getUnreadMessages(messageRoomId, context)
+      return unreadMessages.length
     },
-  };
-};
+  }
+}

--- a/server/app/data/types/MessageRoom.js
+++ b/server/app/data/types/MessageRoom.js
@@ -7,7 +7,6 @@ type MessageRoom {
   lastActivity: Date
   lastMessageTime: Date
   title: String
-  otherUsername: String
   avatar: JSON
   unreadMessages: Int
   postId: String

--- a/server/app/data/types/MessageRoom.js
+++ b/server/app/data/types/MessageRoom.js
@@ -7,6 +7,7 @@ type MessageRoom {
   lastActivity: Date
   lastMessageTime: Date
   title: String
+  otherUsername: String
   avatar: JSON
   unreadMessages: Int
   postId: String
@@ -21,4 +22,4 @@ type PostDetails {
   userId: ID
   url: String
 }
-`;
+`


### PR DESCRIPTION
# Description

Chat sidebar items (usernames and post titles) were not clickable. Users could not navigate to a profile or post page from the chat. This PR adds navigation links to user and post items across the chat sidebar, buddy list, conversation header, and message avatars/names. The chat drawer also closes automatically on navigation.

DM profile navigation uses an on-click lazy query (`GET_USER_BY_ID`) to fetch the username, avoiding any deploy-order dependency between client and server.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactoring, documentation, or other non-functional changes)

## Related Issue

Fixes: [Chat Sidebar Items Do Not Link to Profile or Post](https://github.com/QuoteVote/quotevote-monorepo/issues/118)

## Changes

### Client (5 files)
- **`client/src/graphql/query.jsx`** — Added `GET_USER_BY_ID` query to fetch a user's username by their ID on-click.
- **`client/src/components/Chat/ChatList.jsx`** — DM names fetch the username via lazy query on-click and navigate to `/Profile/:username/`. Group names link to the post URL. Click on the name navigates; click elsewhere on the item opens the chat. Drawer closes on navigation.
- **`client/src/components/BuddyList/BuddyItemList.jsx`** — Buddy names are clickable links to profile pages. Post items link to the post page. Drawer closes on navigation.
- **`client/src/components/Chat/MessageBox.jsx`** — Conversation header title and avatar are clickable, navigating to the profile (DMs via lazy query) or post page (groups). Drawer closes on navigation.
- **`client/src/components/Chat/MessageItem.jsx`** — Message sender avatars and names inside conversations link to the sender's profile page. Drawer closes on navigation.

## Verification

- **DM → Profile**: Clicked username in Chats tab → navigated to `/Profile/<username>/`. Drawer closed.
- **Group → Post**: Clicked post title in Groups tab → navigated to post page. Drawer closed.
- **Conversation Header**: Clicked title/avatar in open conversation → navigated correctly.
- **Message Avatars**: Clicked sender avatar/name in group chat → navigated to sender's profile.
- **Hover states**: Underline + color change on names, opacity change on avatars — clear clickable affordance.
- **Non-navigation clicks**: Clicking the list item area (not the name) still opens the chat as before.
- **Keyboard accessibility**: Enter key triggers navigation on focused links.
- **Deploy preview**: No server-side schema changes required — client works against existing production API.

## Checklist:

- [x] I have read the [**Contributing Guidelines**](/CONTRIBUTING.md).
- [x] My code follows the [**Code Style**](/docs/contributing/code-style.md) of this project.
- [ ] I have added tests that prove my fix is effective or that my feature works. See [**Testing Guidelines**](/docs/contributing/testing.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.