### PR TITLE
fix(docker-compose.yaml): add mongo healthcheck and fix server startup race condition

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,7 +43,8 @@ services:
       - ./server:/app/server
       - /app/server/node_modules
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
   mongo:
     container_name: "quotevote-mongo"
     build:
@@ -56,9 +57,15 @@ services:
       - "quotevote-dev-data:/data/db"
     networks:
       - quotevote-net
+    healthcheck:
+       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+       interval: 10s
+       timeout: 5s
+       retries: 5
+       start_period: 10s
 
   mongo-express:
-    image: mongo-express:1.0.0-alpha.4 
+    image: mongo-express:1.0.2
     restart: always
     ports:
       - 8081:8081


### PR DESCRIPTION
## Description

This PR fixes a race condition between the `server` and `mongo` containers on cold starts. The `server` service was configured with a bare `depends_on: mongo`, which only waits for the MongoDB container to start — not for MongoDB to be ready to accept connections. This caused the Node.js server to attempt a connection before `mongod` finished initializing, relying on `restart: always` to recover silently.

## Changes

- **Healthcheck added to `mongo`**: Docker now runs `db.adminCommand('ping')` every 10 seconds to determine when MongoDB is genuinely ready.
- **`depends_on` updated on `server`**: Changed from a bare service dependency to `condition: service_healthy`, so the server only starts after MongoDB passes its healthcheck.
- **`mongo-express` version bump**: Updated from `1.0.0-alpha.4` (unmaintained alpha) to `1.0.2` (current stable).

## Verification

- Ran `docker compose down -v && docker compose up --force-recreate` and confirmed `quotevote-server` waits for MongoDB to be healthy before starting.
- Confirmed `MongoDB Connected...` log appears only after the healthcheck passes.
- Confirmed `mongo-express` UI loads correctly on `http://localhost:8081`.

## Related Issue

Fixes #312