### PR TITLE
fix(jsconfig): remove deprecated baseUrl and update paths to explicit relative prefixes

### DIFF
--- a/client/jsconfig.json
+++ b/client/jsconfig.json
@@ -1,18 +1,17 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "layouts/*": ["src/layouts/*"],
-      "components/*": ["src/components/*"],
-      "config/*": ["src/config/*"],
-      "store/*": ["src/store/*"],
-      "assets/*": ["src/assets/*"],
-      "utils/*": ["src/utils/*"],
-      "views/*": ["src/views/*"],
-      "mui-pro/*": ["src/mui-pro/*"],
-      "hoc/*": ["src/hoc/*"],
-      "themes/*": ["src/themes/*"]
+      "@/*": ["./src/*"],
+      "layouts/*": ["./src/layouts/*"],
+      "components/*": ["./src/components/*"],
+      "config/*": ["./src/config/*"],
+      "store/*": ["./src/store/*"],
+      "assets/*": ["./src/assets/*"],
+      "utils/*": ["./src/utils/*"],
+      "views/*": ["./src/views/*"],
+      "mui-pro/*": ["./src/mui-pro/*"],
+      "hoc/*": ["./src/hoc/*"],
+      "themes/*": ["./src/themes/*"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## Description

This PR removes the deprecated `baseUrl` option from `client/jsconfig.json` and updates all path entries to use explicit relative prefixes.

Since TypeScript 4.1, `paths` no longer requires `baseUrl` to be set. In TypeScript 6.0, `baseUrl` was formally deprecated and will stop functioning entirely in TypeScript 7.0, causing the following IDE warning:

```
Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
```

## Changes

- **Removed `baseUrl: "."` from `compilerOptions`**: No longer required when using `paths`.
- **Updated all path entries to explicit relative prefixes**: e.g. `"src/*"` → `"./src/*"` to preserve the same resolution behavior without relying on `baseUrl`.

## Verification

- Confirmed no deprecation warning appears in VS Code after the change.
- Confirmed path aliases resolve correctly — no import errors across the codebase.
- Confirmed the client builds without errors: `npm run build --workspace=client`.

## Related Issue

Fixes #316