### PR TITLE
fix(getUserFollowInfo): replace isUndefined with null-safe check for missing user

### DIFF
--- a/server/app/data/resolvers/queries/user/getUserFollowInfo.js
+++ b/server/app/data/resolvers/queries/user/getUserFollowInfo.js
@@ -1,4 +1,3 @@
-import { isUndefined } from 'lodash';
 import UserModel from '../../models/UserModel';
 import VotesModel from '../../models/VoteModel';
 import * as utils from '../../utils';
@@ -17,7 +16,7 @@ export function getUserFollowInfo() {
     const username = args && args.username;
     const filter = args && args.filter;
     const userData = await UserModel.findOne({ username });
-    if (isUndefined(userData)) {
+    if (!userData) {
       return {
         error: true,
         message: 'No user found',


### PR DESCRIPTION
## Description

This PR fixes a bug in `getUserFollowInfo.js` where the existence check for a user was using `isUndefined(userData)` from lodash. `UserModel.findOne()` returns `null` when no document is found, not `undefined`. Since `isUndefined(null)` evaluates to `false`, the guard never triggered, causing the function to attempt accessing `userData._followingId` on a `null` object and throwing:

```
TypeError: Cannot read properties of null (reading '_followingId')
```

## Changes

- **Replaced `isUndefined(userData)` with `!userData`**: Correctly handles both `null` and `undefined` return values from Mongoose.
- **Removed unused `isUndefined` import from lodash**: The import is no longer needed after the fix.

## Verification

- Confirmed that calling `getUserFollowInfo` with a non-existent username now returns `{ error: true, message: 'No user found' }` instead of throwing a TypeError.

## Related Issue

Fixes #323