### PR TITLE
fix(railway): add .npmrc with legacy-peer-deps to fix Nixpacks build conflict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Description

This PR fixes the Railway build failure caused by a peer dependency conflict between `react@17.0.2` and `@livechat/ui-kit@0.3.0-7`, which requires `react@^16.3.0`.

Nixpacks runs `npm install` during the Railway build without the `--legacy-peer-deps` flag, causing an `ERESOLVE` error. The project already uses `--legacy-peer-deps` in its `install:all` script, but Nixpacks does not pick that up automatically.

Adding a `.npmrc` file at the monorepo root with `legacy-peer-deps=true` makes the flag available at the build level regardless of which command Railway runs.

## Changes

- **Added `.npmrc` at monorepo root**: Sets `legacy-peer-deps=true` to resolve the Nixpacks peer dependency conflict during Railway builds.

## Verification

- This fix is consistent with Railway's own build diagnosis suggestion.
- The existing `--legacy-peer-deps` flag in `install:all` confirms this is the intended approach for this project.

## Related Issue

Related to the Railway build failures observed in #328 and previous deploys.