### PR TITLE
export search schema types

### DIFF
--- a/server/app/data/types/index.js
+++ b/server/app/data/types/index.js
@@ -3,6 +3,8 @@ export * from './Activities';
 export * from './Pagination';
 export * from './Comment';
 export * from './ChatRooms';
+export * from './Content';
+export * from './Creator';
 export * from './Group';
 export * from './Message';
 export * from './MessageRoom';


### PR DESCRIPTION
## Description

Adds the missing exports for `Content` and `Creator` types in `server/app/data/types/index.js`.

These types were added in #328 to support the `searchContent` and `searchCreator` resolvers, but were not exported from the central type registry. Apollo loads types exclusively through this index, so without these exports the server schema fails to initialize on startup, causing the Railway deployment to fail.

## Changes

- **Updated `server/app/data/types/index.js`**: Added `export * from './Content'` and `export * from './Creator'`.

## Related Issue

Fixes Railway deployment failure introduced in #328.