### PR TITLE
CI: the GitHub Actions npm cache configuration for the monorepo setup to resolve the deployment failures during CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+        cache-dependency-path: |
+          server/package-lock.json
+          client/package-lock.json
 
     - name: Clean install (workaround for Vite/Rollup native module bug)
       run: |


### PR DESCRIPTION
# This PR fixes the GitHub Actions npm cache configuration for the monorepo setup.

actions/setup-node was using cache: 'npm', which expects a lockfile at the repository root. Since this project stores lockfiles inside server/ and client/, the workflow failed during the setup step with a “Dependencies lock file is not found” error, causing deploys to fail.

## Changes

Updated .github/workflows/main.yml:

Added cache-dependency-path to point to:
server/package-lock.json
client/package-lock.json

This allows setup-node to correctly locate the lockfiles and restore the npm cache in the monorepo environment.