### PR TITLE
Fix chat sidebar navigation links

### DIFF
--- a/client/src/components/BuddyList/BuddyItemList.jsx
+++ b/client/src/components/BuddyList/BuddyItemList.jsx
@@ -251,6 +251,7 @@ function BuddyItemList({ buddyList }) {
           messageType: 'USER',
           title: item.user.name || item.user.username,
           avatar: item.user.avatar,
+          otherUser: item.user,
           isDirect: true,
         }
         dispatch(SELECTED_CHAT_ROOM({ room: roomData }))

--- a/client/src/components/Chat/ChatList.jsx
+++ b/client/src/components/Chat/ChatList.jsx
@@ -1,14 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from '@apollo/react-hooks';
 import { useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { makeStyles, List, ListItem, ListItemAvatar, ListItemText, Typography, Avatar, Chip } from '@material-ui/core';
 import ChatBubbleOutlineIcon from '@material-ui/icons/ChatBubbleOutline';
 import GroupIcon from '@material-ui/icons/Group';
-import { GET_CHAT_ROOMS, GET_USER } from '../../graphql/query';
+import { GET_CHAT_ROOMS } from '../../graphql/query';
 import { SELECTED_CHAT_ROOM } from '../../store/chat';
 import LoadingSpinner from '../LoadingSpinner';
 import AvatarDisplay from '../Avatar';
+import { getChatRoomNavigationLabel, getChatRoomNavigationPath } from '../../utils/chatNavigation';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -84,10 +86,34 @@ const useStyles = makeStyles((theme) => ({
     transition: 'all 0.2s ease',
   },
   primaryText: {
+    display: 'block',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
     fontSize: '0.875rem',
     fontWeight: 600,
     color: theme.palette.text.primary,
     letterSpacing: '-0.01em',
+  },
+  itemLink: {
+    flex: '1 1 auto',
+    minWidth: 0,
+    color: 'inherit',
+    textDecoration: 'none',
+    borderRadius: 6,
+    outline: 'none',
+    '&:hover $primaryText': {
+      color: '#52b274',
+      textDecoration: 'underline',
+    },
+    '&:focus $primaryText': {
+      color: '#52b274',
+      textDecoration: 'underline',
+    },
+    '&:focus-visible': {
+      outline: `2px solid ${theme.palette.primary.main}`,
+      outlineOffset: 3,
+    },
   },
   lastMessage: {
     overflow: 'hidden',
@@ -131,15 +157,14 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     alignItems: 'center',
     gap: theme.spacing(0.5),
+    minWidth: 0,
   },
 }));
 
 const ChatList = ({ search, filterType }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
-  const currentUser = useSelector((state) => state.user.data);
   const selectedRoom = useSelector((state) => state.chat.selectedRoom);
-  const [userCache, setUserCache] = useState({});
 
   const { loading, data, refetch } = useQuery(GET_CHAT_ROOMS, {
     fetchPolicy: 'cache-and-network',
@@ -245,6 +270,8 @@ const ChatList = ({ search, filterType }) => {
       {sortedRooms.map((room) => {
         const displayInfo = getRoomDisplayInfo(room);
         const isSelected = selectedRoom?.room?._id === room._id;
+        const navigationPath = getChatRoomNavigationPath(room);
+        const navigationLabel = getChatRoomNavigationLabel(room, displayInfo.name);
 
         return (
           <ListItem
@@ -268,7 +295,18 @@ const ChatList = ({ search, filterType }) => {
             <ListItemText
               primary={
                 <div className={classes.primaryTextContainer}>
-                  <span className={classes.primaryText}>{displayInfo.name}</span>
+                  {navigationPath ? (
+                    <Link
+                      to={navigationPath}
+                      className={classes.itemLink}
+                      aria-label={navigationLabel}
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      <span className={classes.primaryText}>{displayInfo.name}</span>
+                    </Link>
+                  ) : (
+                    <span className={classes.primaryText}>{displayInfo.name}</span>
+                  )}
                   <Chip
                     size="small"
                     icon={room.messageType === 'USER' && room.users?.length === 2 ? <ChatBubbleOutlineIcon /> : <GroupIcon />}
@@ -303,4 +341,3 @@ ChatList.defaultProps = {
 };
 
 export default ChatList;
-

--- a/client/src/components/Chat/MessageBox.jsx
+++ b/client/src/components/Chat/MessageBox.jsx
@@ -18,6 +18,7 @@ import RemoveCircleIcon from '@material-ui/icons/RemoveCircle'
 import DeleteIcon from '@material-ui/icons/Delete'
 import { useDispatch, useSelector } from 'react-redux'
 import { useMutation, useQuery } from '@apollo/react-hooks'
+import { Link } from 'react-router-dom'
 import MessageSend from './MessageSend'
 import MessageItemList from './MessageItemList'
 import TypingIndicator from './TypingIndicator'
@@ -28,6 +29,7 @@ import { GET_CHAT_ROOMS, GET_ROOM_MESSAGES, GET_ROSTER } from '../../graphql/que
 import useGuestGuard from '../../utils/useGuestGuard'
 import { useRosterManagement } from '../../hooks/useRosterManagement'
 import { SET_SNACKBAR as SET_UI_SNACKBAR } from '../../store/ui'
+import { getChatRoomNavigationLabel, getChatRoomNavigationPath } from '../../utils/chatNavigation'
 
 function useWindowSize() {
   const [windowSize, setWindowSize] = useState({
@@ -90,6 +92,29 @@ const useStyles = makeStyles((theme) => ({
   headerText: {
     flex: 1,
     minWidth: 0,
+  },
+  headerLink: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    flex: 1,
+    minWidth: 0,
+    color: 'inherit',
+    textDecoration: 'none',
+    borderRadius: 10,
+    outline: 'none',
+    '&:hover $title': {
+      color: '#52b274',
+      textDecoration: 'underline',
+    },
+    '&:focus $title': {
+      color: '#52b274',
+      textDecoration: 'underline',
+    },
+    '&:focus-visible': {
+      outline: `2px solid ${theme.palette.primary.main}`,
+      outlineOffset: 3,
+    },
   },
   title: {
     fontWeight: 700,
@@ -190,6 +215,8 @@ function Header() {
   const { data: rosterData } = useQuery(GET_ROSTER, { skip: !currentUser })
 
   const { title, avatar, messageType, users, _id: messageRoomId } = selectedRoom || {}
+  const navigationPath = getChatRoomNavigationPath(selectedRoom)
+  const navigationLabel = getChatRoomNavigationLabel(selectedRoom, title || 'Chat')
 
   // Get the other user's ID for USER type rooms
   const currentUserIdForHeader = currentUser?._id?.toString()
@@ -298,6 +325,29 @@ function Header() {
   }
 
   const menuOpen = Boolean(anchorEl)
+  const avatarNode = (
+    <Avatar className={classes.avatar}>
+      {avatar && Object.keys(avatar).length > 0 ? (
+        <AvatarDisplay height={40} width={40} {...avatar} />
+      ) : messageType === 'USER' && title ? (
+        title[0]?.toUpperCase() || '?'
+      ) : title ? (
+        title[0]?.toUpperCase() || '?'
+      ) : (
+        '?'
+      )}
+    </Avatar>
+  )
+  const headerTextNode = (
+    <div className={classes.headerText}>
+      <Typography className={classes.title}>
+        {title || 'Chat'}
+      </Typography>
+      <Typography className={classes.subtitle}>
+        {messageType === 'USER' ? 'Direct Message' : 'Group Chat'}
+      </Typography>
+    </div>
+  )
 
   return (
     <Fade in timeout={300}>
@@ -307,26 +357,21 @@ function Header() {
             <ArrowBackIcon fontSize="small" />
           </IconButton>
 
-          <Avatar className={classes.avatar}>
-            {avatar && Object.keys(avatar).length > 0 ? (
-              <AvatarDisplay height={40} width={40} {...avatar} />
-            ) : messageType === 'USER' && title ? (
-              title[0]?.toUpperCase() || '?'
-            ) : title ? (
-              title[0]?.toUpperCase() || '?'
-            ) : (
-              '?'
-            )}
-          </Avatar>
-
-          <div className={classes.headerText}>
-            <Typography className={classes.title}>
-              {title || 'Chat'}
-            </Typography>
-            <Typography className={classes.subtitle}>
-              {messageType === 'USER' ? 'Direct Message' : 'Group Chat'}
-            </Typography>
-          </div>
+          {navigationPath ? (
+            <Link
+              to={navigationPath}
+              className={classes.headerLink}
+              aria-label={navigationLabel}
+            >
+              {avatarNode}
+              {headerTextNode}
+            </Link>
+          ) : (
+            <>
+              {avatarNode}
+              {headerTextNode}
+            </>
+          )}
 
           <IconButton
             onClick={handleSettingsClick}

--- a/client/src/graphql/query.jsx
+++ b/client/src/graphql/query.jsx
@@ -170,6 +170,12 @@ export const GET_CHAT_ROOMS = gql`
       avatar
       unreadMessages
       postId
+      otherUser {
+        _id
+        name
+        username
+        avatar
+      }
       postDetails {
         _id
         title

--- a/client/src/utils/chatNavigation.js
+++ b/client/src/utils/chatNavigation.js
@@ -1,0 +1,26 @@
+export const getChatRoomNavigationPath = (room) => {
+  if (!room) return null
+
+  if (room.messageType === 'USER') {
+    const username = room.otherUser?.username || room.user?.username
+    return username ? `/Profile/${username}/` : null
+  }
+
+  if (room.messageType === 'POST') {
+    return room.postDetails?.url || null
+  }
+
+  return null
+}
+
+export const getChatRoomNavigationLabel = (room, fallbackTitle = 'chat') => {
+  if (room?.messageType === 'USER') {
+    return `View profile for ${room.otherUser?.username || fallbackTitle}`
+  }
+
+  if (room?.messageType === 'POST') {
+    return `View post ${fallbackTitle}`
+  }
+
+  return undefined
+}

--- a/server/app/data/resolvers/relationship/message_room_relationship.js
+++ b/server/app/data/resolvers/relationship/message_room_relationship.js
@@ -118,5 +118,21 @@ export const messageRoomRelationship = () => {
       const unreadMessages = await getUnreadMessages(messageRoomId, context);
       return unreadMessages.length;
     },
+    async otherUser(data, root, context) {
+      const { users, messageType } = data;
+      const contextUserId = context.user?.['_id']?.toString();
+
+      if (messageType !== 'USER' || !contextUserId || !users?.length) {
+        return null;
+      }
+
+      const otherUserId = users.find((user) => user.toString() !== contextUserId);
+
+      if (!otherUserId) {
+        return null;
+      }
+
+      return UserModel.findById(new ObjectId(otherUserId));
+    },
   };
 };

--- a/server/app/data/types/MessageRoom.js
+++ b/server/app/data/types/MessageRoom.js
@@ -10,6 +10,7 @@ type MessageRoom {
   avatar: JSON
   unreadMessages: Int
   postId: String
+  otherUser: User
   messages: [Message]
   postDetails: PostDetails
 }


### PR DESCRIPTION
Closes #118

Summary:
- Made user chat items navigate to profile pages
- Made post chat items navigate to post pages
- Preserved existing chat sidebar behavior
- Added clickable/focus styling where needed

Testing:
- npm run lint:client passed with existing warnings
- npm run build:client passed
- npm run build:server passed
- npm run test:server passed
