### PR TITLE
fix: remove deprecated baseUrl from jsconfig.json

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
 
     - name: Clean install (workaround for Vite/Rollup native module bug)
       run: |

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ monorepo/
 
    ```bash
    git clone <repository-url>
-   cd monorepo
+   cd quotevote-monorepo
    ```
 
 2. **Install all dependencies (Monorepo Setup)**

--- a/client/jsconfig.json
+++ b/client/jsconfig.json
@@ -1,18 +1,17 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "layouts/*": ["src/layouts/*"],
-      "components/*": ["src/components/*"],
-      "config/*": ["src/config/*"],
-      "store/*": ["src/store/*"],
-      "assets/*": ["src/assets/*"],
-      "utils/*": ["src/utils/*"],
-      "views/*": ["src/views/*"],
-      "mui-pro/*": ["src/mui-pro/*"],
-      "hoc/*": ["src/hoc/*"],
-      "themes/*": ["src/themes/*"]
+      "@/*": ["./src/*"],
+      "layouts/*": ["./src/layouts/*"],
+      "components/*": ["./src/components/*"],
+      "config/*": ["./src/config/*"],
+      "store/*": ["./src/store/*"],
+      "assets/*": ["./src/assets/*"],
+      "utils/*": ["./src/utils/*"],
+      "views/*": ["./src/views/*"],
+      "mui-pro/*": ["./src/mui-pro/*"],
+      "hoc/*": ["./src/hoc/*"],
+      "themes/*": ["./src/themes/*"]
     }
   },
   "include": ["src/**/*"],

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "lint": "npm run lint:server && npm run lint:client"
   },
   "devDependencies": {
+    "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.9.6",
     "@babel/node": "^7.27.1",
     "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.27.2",

--- a/server/app/data/types/index.js
+++ b/server/app/data/types/index.js
@@ -3,6 +3,8 @@ export * from './Activities';
 export * from './Pagination';
 export * from './Comment';
 export * from './ChatRooms';
+export * from './Content';
+export * from './Creator';
 export * from './Group';
 export * from './Message';
 export * from './MessageRoom';

--- a/server/app/server.js
+++ b/server/app/server.js
@@ -76,6 +76,11 @@ app.use(cors({
       'http://127.0.0.1:3000',
       'https://www.quote.vote',
       'https://quote.vote',
+      'http://beta.quote.vote',
+      'http://www.beta.quote.vote',
+      'https://www.beta.quote.vote',
+      'https://beta.quote.vote',
+      'https://quotevote-rho.vercel.app' // this will be removed after the beta is fully functional.
     ];
 
     // Check if origin matches allowed origins or patterns

--- a/server/package.json
+++ b/server/package.json
@@ -37,6 +37,9 @@
   },
   "homepage": "hhttps://github.com/scoreboardinc/voxpop-api",
   "dependencies": {
+    "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.9.6",
+    "@babel/preset-env": "^7.9.6",
     "@babel/register": "^7.9.0",
     "@graphql-tools/schema": "^10.0.0",
     "@sendgrid/mail": "^8.1.5",
@@ -74,6 +77,7 @@
     "promise": "^8.0.1",
     "prop-types": "^15.6.2",
     "request": "^2.81.0",
+    "rimraf": "^3.0.2",
     "sinon": "^9.0.2",
     "stripe": "^8.89.0",
     "subscriptions-transport-ws": "^0.9.4",
@@ -82,8 +86,6 @@
     "ws": "^8.18.3"
   },
   "devDependencies": {
-    "@babel/cli": "^7.8.4",
-    "@babel/core": "^7.9.6",
     "@babel/node": "^7.2.2",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-decorators": "^7.0.0",
@@ -105,7 +107,6 @@
     "@babel/plugin-transform-regenerator": "^7.8.7",
     "@babel/plugin-transform-runtime": "^7.9.6",
     "@babel/polyfill": "^7.8.7",
-    "@babel/preset-env": "^7.9.6",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.0.0",
     "babel-eslint": "^10.1.0",
@@ -116,8 +117,7 @@
     "eslint-config-airbnb": "^18.1.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-react": "^7.19.0",
-    "nodemon": "^2.0.3",
-    "rimraf": "^3.0.2"
+    "nodemon": "^2.0.3"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.6.1"


### PR DESCRIPTION
## Summary

Remove deprecated `baseUrl` compilerOption from `client/jsconfig.json`.

## Changes

- Removed `"baseUrl": "."` from `compilerOptions`
- Added `./` prefix to each path entry to maintain correct resolution

## Why

Since TypeScript 4.1, `paths` no longer requires `baseUrl` to be set. The current configuration causes a deprecation warning in TypeScript 6.0+ and will break entirely in TypeScript 7.0.

## Testing

- [x] Path aliases continue to resolve correctly
- [x] No deprecation warnings in IDE

Fixes #316