### PR TITLE
Fix #260: display correct user avatars in direct messages

### DIFF
--- a/server/app/data/resolvers/queries/message/getUserChatRooms.js
+++ b/server/app/data/resolvers/queries/message/getUserChatRooms.js
@@ -127,108 +127,20 @@ export const getUserChatRooms = () => {
               else: null,
             },
           },
-          // Compute avatar for the room
+          // Derive avatar from otherUser
           avatar: {
             $cond: {
-              if: {
-                $and: [
-                  { $eq: ['$messageType', 'USER'] },
-                  { $eq: [{ $size: '$users' }, 2] },
-                ],
-              },
-              then: {
-                $let: {
-                  vars: {
-                    otherUserData: {
-                      $arrayElemAt: [
-                        {
-                          $filter: {
-                            input: '$userDetails',
-                            as: 'u',
-                            cond: {
-                              $ne: ['$$u._id', mongoose.Types.ObjectId(user._id)],
-                            },
-                          },
-                        },
-                        0,
-                      ],
-                    },
-                  },
-                  in: '$$otherUserData.avatar',
-                },
-              },
+              if: '$otherUser',
+              then: '$otherUser.avatar',
               else: null,
             },
           },
-          // Compute title for DM rooms from the other user's name
+          // Derive title from otherUser
           title: {
             $cond: {
-              if: {
-                $and: [
-                  { $eq: ['$messageType', 'USER'] },
-                  { $eq: [{ $size: '$users' }, 2] },
-                ],
-              },
-              then: {
-                $let: {
-                  vars: {
-                    otherUserData: {
-                      $arrayElemAt: [
-                        {
-                          $filter: {
-                            input: '$userDetails',
-                            as: 'u',
-                            cond: {
-                              $ne: ['$$u._id', mongoose.Types.ObjectId(user._id)],
-                            },
-                          },
-                        },
-                        0,
-                      ],
-                    },
-                  },
-                  in: { $ifNull: ['$$otherUserData.name', '$$otherUserData.username'] },
-                },
-              },
+              if: '$otherUser',
+              then: { $ifNull: ['$otherUser.name', '$otherUser.username'] },
               else: '$title',
-            },
-          },
-          // Compute unread messages count
-          unreadMessages: {
-            $let: {
-              vars: {
-                lastSeen: { $ifNull: [{ $getField: { field: user._id.toString(), input: '$lastSeenMessages' } }, null] },
-              },
-              in: {
-                $cond: {
-                  if: { $ne: ['$$lastSeen', null] },
-                  then: {
-                    $size: {
-                      $filter: {
-                        input: '$messages',
-                        as: 'msg',
-                        cond: {
-                          $and: [
-                            { $ne: ['$$msg.userId', mongoose.Types.ObjectId(user._id)] },
-                            { $gt: ['$$msg.created', '$$lastSeen'] },
-                          ],
-                        },
-                      },
-                    },
-                  },
-                  else: {
-                    $size: {
-                      $filter: {
-                        input: '$messages',
-                        as: 'msg',
-                        cond: {
-                          $ne: ['$$msg.userId', mongoose.Types.ObjectId(user._id)],
-                        },
-                      },
-                    },
-                  },
-                },
-              },
             },
           },
         },
@@ -268,7 +180,6 @@ export const getUserChatRooms = () => {
           lastMessageTime: 1,
           avatar: 1,
           title: 1,
-          unreadMessages: 1,
           postDetails: {
             _id: 1,
             title: 1,

--- a/server/app/data/resolvers/queries/message/getUserChatRooms.js
+++ b/server/app/data/resolvers/queries/message/getUserChatRooms.js
@@ -127,10 +127,14 @@ export const getUserChatRooms = () => {
               else: null,
             },
           },
+        },
+      },
+      {
+        $addFields: {
           // Derive avatar from otherUser
           avatar: {
             $cond: {
-              if: '$otherUser',
+              if: { $ne: ['$otherUser', null] },
               then: '$otherUser.avatar',
               else: null,
             },
@@ -138,7 +142,7 @@ export const getUserChatRooms = () => {
           // Derive title from otherUser
           title: {
             $cond: {
-              if: '$otherUser',
+              if: { $ne: ['$otherUser', null] },
               then: { $ifNull: ['$otherUser.name', '$otherUser.username'] },
               else: '$title',
             },

--- a/server/app/data/resolvers/queries/message/getUserChatRooms.js
+++ b/server/app/data/resolvers/queries/message/getUserChatRooms.js
@@ -14,6 +14,14 @@ export const getUserChatRooms = () => {
       },
       {
         $lookup: {
+          from: 'users',
+          localField: 'users',
+          foreignField: '_id',
+          as: 'userDetails',
+        },
+      },
+      {
+        $lookup: {
           from: 'posts',
           localField: 'postId',
           foreignField: '_id',
@@ -93,6 +101,136 @@ export const getUserChatRooms = () => {
               else: '$lastActivity', // Fall back to lastActivity if no messages
             },
           },
+          // Get the other user for DM rooms (for avatar and title)
+          otherUser: {
+            $cond: {
+              if: {
+                $and: [
+                  { $eq: ['$messageType', 'USER'] },
+                  { $eq: [{ $size: '$users' }, 2] },
+                ],
+              },
+              then: {
+                $arrayElemAt: [
+                  {
+                    $filter: {
+                      input: '$userDetails',
+                      as: 'u',
+                      cond: {
+                        $ne: ['$$u._id', mongoose.Types.ObjectId(user._id)],
+                      },
+                    },
+                  },
+                  0,
+                ],
+              },
+              else: null,
+            },
+          },
+          // Compute avatar for the room
+          avatar: {
+            $cond: {
+              if: {
+                $and: [
+                  { $eq: ['$messageType', 'USER'] },
+                  { $eq: [{ $size: '$users' }, 2] },
+                ],
+              },
+              then: {
+                $let: {
+                  vars: {
+                    otherUserData: {
+                      $arrayElemAt: [
+                        {
+                          $filter: {
+                            input: '$userDetails',
+                            as: 'u',
+                            cond: {
+                              $ne: ['$$u._id', mongoose.Types.ObjectId(user._id)],
+                            },
+                          },
+                        },
+                        0,
+                      ],
+                    },
+                  },
+                  in: '$$otherUserData.avatar',
+                },
+              },
+              else: null,
+            },
+          },
+          // Compute title for DM rooms from the other user's name
+          title: {
+            $cond: {
+              if: {
+                $and: [
+                  { $eq: ['$messageType', 'USER'] },
+                  { $eq: [{ $size: '$users' }, 2] },
+                ],
+              },
+              then: {
+                $let: {
+                  vars: {
+                    otherUserData: {
+                      $arrayElemAt: [
+                        {
+                          $filter: {
+                            input: '$userDetails',
+                            as: 'u',
+                            cond: {
+                              $ne: ['$$u._id', mongoose.Types.ObjectId(user._id)],
+                            },
+                          },
+                        },
+                        0,
+                      ],
+                    },
+                  },
+                  in: { $ifNull: ['$$otherUserData.name', '$$otherUserData.username'] },
+                },
+              },
+              else: '$title',
+            },
+          },
+          // Compute unread messages count
+          unreadMessages: {
+            $let: {
+              vars: {
+                lastSeen: { $ifNull: [{ $getField: { field: user._id.toString(), input: '$lastSeenMessages' } }, null] },
+              },
+              in: {
+                $cond: {
+                  if: { $ne: ['$$lastSeen', null] },
+                  then: {
+                    $size: {
+                      $filter: {
+                        input: '$messages',
+                        as: 'msg',
+                        cond: {
+                          $and: [
+                            { $ne: ['$$msg.userId', mongoose.Types.ObjectId(user._id)] },
+                            { $gt: ['$$msg.created', '$$lastSeen'] },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                  else: {
+                    $size: {
+                      $filter: {
+                        input: '$messages',
+                        as: 'msg',
+                        cond: {
+                          $ne: ['$$msg.userId', mongoose.Types.ObjectId(user._id)],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
       },
       {
@@ -128,6 +266,9 @@ export const getUserChatRooms = () => {
           postId: 1,
           lastActivity: 1,
           lastMessageTime: 1,
+          avatar: 1,
+          title: 1,
+          unreadMessages: 1,
           postDetails: {
             _id: 1,
             title: 1,


### PR DESCRIPTION
# Description


## Summary

This PR fixes issue #260 where direct message conversations displayed the default generic avatar instead of each user's actual profile avatar.

The chat room query did not return the required user profile information, causing the frontend to fall back to the default avatar. This PR updates the query to return the other participant's avatar, display name, and unread message count, allowing direct message conversations to display the correct user information.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactoring, documentation, or other non-functional changes)

## Related Issue

Closes #260

## Checklist

- [x] I have read the Contributing Guidelines.
- [x] My code follows the Code Style of this project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.