### PR TITLE
fix(auth): verify JWTs with the same secret used to sign them

### DIFF
--- a/server/app/data/utils/authentication.js
+++ b/server/app/data/utils/authentication.js
@@ -118,6 +118,24 @@ const invalidUserPassword = (res) => {
     .json({ message: 'Invalid username or password.' });
 };
 
+/**
+ * Single source of truth for the JWT secret.
+ *
+ * Signing and verification MUST read the same variable. They diverged once
+ * (signing on SECRET, verifying on JWT_SECRET), which silently invalidated
+ * every token in production. Going through this helper keeps them together,
+ * and throwing on an unset value fails loudly instead of failing one token
+ * at a time. `SECRET` is the name the deployment provisions — see
+ * app/ecosystem.config.js and deploy/.
+ */
+export const getAuthSecret = () => {
+  const secret = process.env.SECRET;
+  if (!secret) {
+    throw new Error('SECRET is not set — JWTs cannot be signed or verified.');
+  }
+  return secret;
+};
+
 export const addCreatorToUser = async ({ username, password, requirePassword }, res, authenticate, expiresIn = (60 * 60 * 24), tokenOnly = false) => {
   let query;
   if (/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(username)) {
@@ -154,7 +172,7 @@ export const addCreatorToUser = async ({ username, password, requirePassword }, 
     admin: updatedUser.admin,
     primary: updatedUser.primary,
   },
-  process.env.SECRET,
+  getAuthSecret(),
   { expiresIn });
 
   if (tokenOnly) {
@@ -216,18 +234,19 @@ export const authenticate = async (req, res) => {
 };
 
 export const verifyToken = (authToken) => {
-  const authSecret = process.env.JWT_SECRET;
-
   if (!authToken || typeof authToken !== 'string') {
     throw new AuthenticationError(
       'Authorization token is missing or invalid'
     );
   }
-  
+
+  // Read before the try block: a missing secret is a deployment fault, not a
+  // bad token, and must not be reported to the caller as an auth failure.
+  const authSecret = getAuthSecret();
+
   // Remove 'Bearer ' prefix if present
   const token = authToken.startsWith('Bearer ') ? authToken.substring(7) : authToken;
-  
-  
+
   try {
     const user = jwt.verify(token, authSecret);
     return { ...user };
@@ -238,8 +257,13 @@ export const verifyToken = (authToken) => {
     }
     if (err.name === 'JsonWebTokenError' || err.message === 'invalid signature') {
       throw new AuthenticationError(`Invalid access token because of ${err.message}`);
-    } else if (err.name === 'TokenExpiredError') {
+    }
+    if (err.name === 'TokenExpiredError') {
       throw new AuthenticationError('Access token has expired');
     }
+    // Every other jwt failure (NotBeforeError, and anything jsonwebtoken adds
+    // later) must still throw. Falling through returned `undefined`, which the
+    // GraphQL context accepted as a valid user and later dereferenced.
+    throw new AuthenticationError('Invalid access token');
   }
 };

--- a/server/app/tests/utils/authentication.test.js
+++ b/server/app/tests/utils/authentication.test.js
@@ -1,0 +1,86 @@
+import jwt from 'jsonwebtoken';
+import { expect } from 'chai';
+import { getAuthSecret, verifyToken } from '~/utils/authentication';
+
+const SECRET = 'test-secret-value';
+
+const signToken = (payload, options = {}) => jwt.sign(payload, SECRET, options);
+
+describe('utils > authentication', () => {
+  let originalSecret;
+
+  beforeEach(() => {
+    originalSecret = process.env.SECRET;
+    process.env.SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.SECRET;
+    } else {
+      process.env.SECRET = originalSecret;
+    }
+  });
+
+  describe('getAuthSecret', () => {
+    it('returns the configured SECRET', () => {
+      expect(getAuthSecret()).to.equal(SECRET);
+    });
+
+    it('throws when SECRET is unset rather than returning undefined', () => {
+      delete process.env.SECRET;
+      expect(() => getAuthSecret()).to.throw(/SECRET is not set/);
+    });
+  });
+
+  describe('verifyToken', () => {
+    // Regression guard: signing and verification must read the same variable.
+    // When they diverged, every token in production failed verification.
+    it('verifies a token signed with the same secret used for signing', () => {
+      const token = signToken({ _id: 'user-1', admin: true });
+      const decoded = verifyToken(token);
+
+      expect(decoded._id).to.equal('user-1');
+      expect(decoded.admin).to.equal(true);
+    });
+
+    it('accepts a token with the Bearer prefix', () => {
+      const token = signToken({ _id: 'user-1' });
+
+      expect(verifyToken(`Bearer ${token}`)._id).to.equal('user-1');
+    });
+
+    it('rejects a token signed with a different secret', () => {
+      const token = jwt.sign({ _id: 'user-1' }, 'some-other-secret');
+
+      expect(() => verifyToken(token)).to.throw(/Invalid access token/);
+    });
+
+    it('rejects an expired token', () => {
+      const token = signToken({ _id: 'user-1' }, { expiresIn: '-1s' });
+
+      expect(() => verifyToken(token)).to.throw(/expired/);
+    });
+
+    it('rejects a missing or non-string token', () => {
+      expect(() => verifyToken(undefined)).to.throw(/missing or invalid/);
+      expect(() => verifyToken(null)).to.throw(/missing or invalid/);
+      expect(() => verifyToken(12345)).to.throw(/missing or invalid/);
+    });
+
+    // Falling through the catch returned `undefined`, which the GraphQL context
+    // accepted as a valid user and later dereferenced as `user._id`.
+    it('throws rather than returning undefined for a not-yet-valid token', () => {
+      const token = signToken({ _id: 'user-1' }, { notBefore: '1h' });
+
+      expect(() => verifyToken(token)).to.throw();
+    });
+
+    it('surfaces a missing secret as a configuration error, not an auth failure', () => {
+      const token = signToken({ _id: 'user-1' });
+      delete process.env.SECRET;
+
+      expect(() => verifyToken(token)).to.throw(/SECRET is not set/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`verifyToken` read `process.env.JWT_SECRET` while `addCreatorToUser` signs with `process.env.SECRET`. `JWT_SECRET` is never provisioned — the deployment sets `SECRET` (`app/ecosystem.config.js:8`, `deploy/setup-droplet.sh`, `deploy/README.md`) — and `JWT_SECRET` appeared exactly once in the entire server.

Every token therefore failed verification. The GraphQL context swallows that failure and continues without a user, so logged-in requests reached resolvers anonymously:

- resolvers that guard returned `Authentication required`
- resolvers that dereference `user._id` threw `Cannot read properties of undefined (reading '_id')` as **HTTP 200** with null data

Login itself kept working, because `/login` never calls `verifyToken` — so users authenticated successfully and then found that everything afterwards failed.

Introduced by #346. Fixes #349.

## Blast radius was wider than the issue recorded

Tracing every `verifyToken` caller turned up two more broken flows:

- **Password reset.** `sendPasswordResetEmail` signs its token via `addCreatorToUser` (with `SECRET`), but `verifyUserPasswordResetToken` and `updateUserPassword` verify via `verifyToken` (with the unset `JWT_SECRET`). Every reset link has been dead since #346.
- **WebSocket subscriptions.** `server.js:279` authenticates the socket through `verifyToken`, so real-time features silently degraded to anonymous.

Both are repaired by this change, and both are internally consistent afterwards — the reset token is signed with the same secret it is now verified with.

## Changes

**Route signing and verification through one accessor.** `getAuthSecret()` reads `SECRET` and throws when unset. The two call sites diverging silently is exactly what caused this outage; going through a single helper means they cannot drift apart again, and an unset secret now fails loudly at the first call rather than failing one token at a time.

**Read the secret before the `try` block.** A missing secret is a deployment fault, not a bad token, and must not be reported to the caller as an authentication failure.

**Always throw from the `catch`.** `NotBeforeError` — and anything `jsonwebtoken` adds later — previously fell through and returned `undefined`, which the context accepted as a valid user before dereferencing `user._id`. That is the same crash by a second route.

## Testing

Adds `app/tests/utils/authentication.test.js` (9 cases, following the existing sinon/chai style): sign/verify round trip, `Bearer` prefix, wrong secret, expired, missing/non-string, not-yet-valid, and missing-secret-is-a-config-error.

**The suite is not vacuous** — reintroducing `process.env.JWT_SECRET` fails 4 of the 9, including the round-trip case that mirrors the production failure.

- `npm run test --workspace=server` — **31 passing**, 8 suites
- `npm run build:server` — compiles 264 files (this is what CI runs)
- Lint: 1066 problems on this branch vs **1067 on `main`** — all pre-existing, one fewer here

## Deployment note

`getAuthSecret()` throws when `SECRET` is unset, so a misconfigured environment now fails fast instead of silently rejecting every token. Please confirm `SECRET` is set before rolling this out.

## Deliberately not included

Two follow-ups from #349 are left for separate PRs:

1. **The context still swallows invalid tokens into an anonymous request** (`server.js:222-228`). Tokens last 24 hours, so on expiry users will hit the same confusing crash rather than a clean re-auth. Fixing this properly requires distinguishing *no token* (stay anonymous) from *invalid token* (reject) — done naively it locks anyone holding a stale token out of public content, so it deserves its own review.
2. **Resolvers that dereference `context.user` without a guard** (`queries/post/topPosts.js`, `queries/post/getFeaturedPosts.js`, `queries/user/findUserById.js`, chat and notification resolvers). Overlaps #352.

## Note on CI

`.github/workflows/main.yml` runs only `build:server` and `build:client` — there is no test or lint step, so the tests added here will not run automatically. Worth adding `test:server` to CI before the #350–#352 work lands, or none of that will be verified either.
