### PR TITLE
feat(profile): add bio and restore presence across reloads

### DIFF
--- a/server/app/data/inputs/UserInput.js
+++ b/server/app/data/inputs/UserInput.js
@@ -4,6 +4,7 @@ input UserInput {
   name: String
   username: String
   email: String
+  bio: String
   password: String
   quotes: [String]
   avatar: String

--- a/server/app/data/resolvers/index.js
+++ b/server/app/data/resolvers/index.js
@@ -33,6 +33,12 @@ const resolvers = {
   Presence: relationship.presenceRelationship(),
   Roster: relationship.rosterRelationship(),
   TypingIndicator: relationship.typingIndicatorRelationship(),
+
+  // user_relationship was never added to this map, so its field resolvers have
+  // never run — User.reputation returns null in production today. Only
+  // `presence` is wired here: enabling `reputation` would start running
+  // ReputationCalculator on every user query, which needs its own review.
+  User: { presence: relationship.user_relationship.User.presence },
 };
 
 export { resolvers };

--- a/server/app/data/resolvers/models/PresenceModel.js
+++ b/server/app/data/resolvers/models/PresenceModel.js
@@ -18,6 +18,18 @@ const schema = mongoose.Schema({
     maxlength: 200,
     default: '',
   },
+  // The status the user last chose for themselves. `status` tracks live state
+  // and may be forced to 'offline' by the cleanup job; these preserve intent
+  // so the next heartbeat can restore it.
+  preferredStatus: {
+    type: String,
+    enum: ['online', 'away', 'dnd', 'invisible', 'offline'],
+  },
+  preferredStatusMessage: {
+    type: String,
+    maxlength: 200,
+    default: '',
+  },
   lastHeartbeat: {
     type: Date,
     required: true,

--- a/server/app/data/resolvers/models/UserModel.js
+++ b/server/app/data/resolvers/models/UserModel.js
@@ -11,6 +11,13 @@ const schema = mongoose.Schema({
   name: {
     type: String,
   },
+  // Profile "About" text. Plain text only; validated in normalizeBio.
+  bio: {
+    type: String,
+    trim: true,
+    maxlength: 500,
+    default: '',
+  },
   companyName: {
     type: String,
   },

--- a/server/app/data/resolvers/mutations/presence/heartbeat.js
+++ b/server/app/data/resolvers/mutations/presence/heartbeat.js
@@ -1,4 +1,5 @@
 import Presence from '../../models/PresenceModel';
+import { pubsub } from '../../subscriptions';
 
 export const heartbeat = async (root, args, context) => {
   const { user } = context;
@@ -23,9 +24,34 @@ export const heartbeat = async (root, args, context) => {
     { upsert: true, new: true },
   );
 
+  // The user is demonstrably here, so the cleanup job should not leave them
+  // marked offline. Restore the status they chose, falling back to online if
+  // they never chose one. A user who deliberately chose 'offline' is left
+  // alone — that is intent, not staleness.
+  if (presence.status === 'offline' && presence.preferredStatus !== 'offline') {
+    presence.status = presence.preferredStatus || 'online';
+    presence.statusMessage = presence.preferredStatusMessage || '';
+    await presence.save();
+
+    // Tell subscribers they are back, mirroring the offline event the cleanup
+    // job publishes. Invisible users are not announced.
+    if (presence.status !== 'invisible') {
+      await pubsub.publish('presenceEvent', {
+        presence: {
+          userId: presence.userId.toString(),
+          status: presence.status,
+          statusMessage: presence.statusMessage,
+          lastSeen: presence.lastSeen,
+        },
+      });
+    }
+  }
+
   return {
     success: true,
     timestamp: presence.lastHeartbeat,
+    status: presence.status,
+    statusMessage: presence.statusMessage,
   };
 };
 

--- a/server/app/data/resolvers/mutations/presence/updatePresence.js
+++ b/server/app/data/resolvers/mutations/presence/updatePresence.js
@@ -23,6 +23,11 @@ export const updatePresence = async (root, { presence }, context) => {
       userId: user._id,
       status,
       statusMessage: statusMessage || '',
+      // This call is the user choosing a status, so record it as their intent.
+      // The cleanup job may later force `status` to offline; `preferredStatus`
+      // is what the next heartbeat restores them to.
+      preferredStatus: status,
+      preferredStatusMessage: statusMessage || '',
       lastHeartbeat: now,
       lastSeen: now,
       expiresAt, // Explicitly set expiresAt for TTL index

--- a/server/app/data/resolvers/mutations/typing/updateTyping.js
+++ b/server/app/data/resolvers/mutations/typing/updateTyping.js
@@ -34,6 +34,6 @@ export const updateTyping = async (root, { typing }, context) => {
     },
   });
 
-  return { success: true };
+  return { success: true, messageRoomId, isTyping };
 };
 

--- a/server/app/data/resolvers/mutations/user/updateUser.js
+++ b/server/app/data/resolvers/mutations/user/updateUser.js
@@ -2,6 +2,7 @@ import bcrypt from 'bcryptjs';
 import { UserInputError } from 'apollo-server-express';
 import UserModel from '../../models/UserModel';
 import { logger } from '../../../utils/logger';
+import { normalizeBio } from '../../../utils/bioValidation';
 import PostModel from '~/resolvers/models/PostModel';
 
 export const updateUser = (pubsub) => {
@@ -34,6 +35,16 @@ export const updateUser = (pubsub) => {
         });
         if (checkEmail) {
           throw new UserInputError('Email address already exists!');
+        }
+      }
+
+      // Only touch bio when the client sent it, so omitting the field leaves
+      // the stored value alone rather than clearing it.
+      if ('bio' in userData) {
+        try {
+          userData.bio = normalizeBio(userData.bio);
+        } catch (err) {
+          throw new UserInputError(err.message);
         }
       }
 

--- a/server/app/data/resolvers/relationship/user_relationship.js
+++ b/server/app/data/resolvers/relationship/user_relationship.js
@@ -1,9 +1,23 @@
 import UserReputationModel from '../models/UserReputationModel';
+import PresenceModel from '../models/PresenceModel';
 import ReputationCalculator from '../utils/reputationCalculator';
 import { logger } from '../../utils/logger';
 
 export const user_relationship = {
   User: {
+    // Only runs when a query selects `presence`, so user lists that omit the
+    // field are unaffected. Null when the user has no presence record yet.
+    presence: async (parent) => {
+      try {
+        return await PresenceModel.findOne({ userId: parent._id });
+      } catch (error) {
+        logger.error('Error getting user presence in relationship', {
+          error: error.message,
+          userId: parent._id,
+        });
+        return null;
+      }
+    },
     reputation: async (parent) => {
       try {
         // Get existing reputation or calculate new one

--- a/server/app/data/types/Presence.js
+++ b/server/app/data/types/Presence.js
@@ -14,6 +14,11 @@ export const Presence = `
     userId: String!
     status: PresenceStatus!
     statusMessage: String
+    # The status the user last chose for themselves. Kept separate from status
+    # so the stale-presence cleanup marking someone offline does not erase
+    # their intent — the next heartbeat restores them to this.
+    preferredStatus: PresenceStatus
+    preferredStatusMessage: String
     lastHeartbeat: Date!
     lastSeen: Date
     user: User
@@ -28,9 +33,14 @@ export const Presence = `
   }
 
   # Heartbeat response
+  #
+  # Returns the caller's presence after the beat so a client that has just
+  # reloaded can restore status without a second round trip.
   type HeartbeatResponse {
     success: Boolean!
     timestamp: Date!
+    status: PresenceStatus
+    statusMessage: String
   }
 `;
 

--- a/server/app/data/types/TypingIndicator.js
+++ b/server/app/data/types/TypingIndicator.js
@@ -9,8 +9,13 @@ export const TypingIndicator = `
   }
 
   # Typing mutation response
+  #
+  # Echoes the room and state back so a client with several open rooms can
+  # correlate a response to the request that produced it.
   type TypingResponse {
     success: Boolean!
+    messageRoomId: String
+    isTyping: Boolean
   }
 `;
 

--- a/server/app/data/types/User.js
+++ b/server/app/data/types/User.js
@@ -6,6 +6,7 @@ type User {
   username: String
   name: String
   email: String
+  bio: String
   tokens: Int
   _wallet: String
   avatar: JSON
@@ -18,6 +19,8 @@ type User {
   downvotes: Int
   contributorBadge: Boolean
   reputation: UserReputation
+  # Resolved on demand — only queried when selected, so user lists are unaffected.
+  presence: Presence
   botReports: Int
   accountStatus: String
   lastBotReportDate: String

--- a/server/app/data/utils/bioValidation.js
+++ b/server/app/data/utils/bioValidation.js
@@ -1,0 +1,41 @@
+/**
+ * Shared validation for user About / bio text.
+ *
+ * Plain text only. BIO_MAX_LENGTH matches the frontend's
+ * PROFILE_BIO_MAX_LENGTH so the client and server agree on what is accepted.
+ */
+
+export const BIO_MAX_LENGTH = 500;
+
+/** Detects HTML / markup that should not be stored as plain-text bio. */
+const HTML_TAG_PATTERN = /<\/?[a-z][\s\S]*>/i;
+
+/**
+ * Normalize and validate bio input for updateUser.
+ *
+ * Returns trimmed plain text, or an empty string when cleared.
+ * Throws with a user-facing message on invalid input.
+ */
+export const normalizeBio = (raw) => {
+  if (raw === null || raw === undefined) {
+    return '';
+  }
+
+  if (typeof raw !== 'string') {
+    throw new Error('About must be text');
+  }
+
+  const trimmed = raw.trim();
+
+  if (trimmed.length > BIO_MAX_LENGTH) {
+    throw new Error(`About must be ${BIO_MAX_LENGTH} characters or fewer`);
+  }
+
+  if (HTML_TAG_PATTERN.test(trimmed)) {
+    throw new Error('About must be plain text without HTML');
+  }
+
+  return trimmed;
+};
+
+export default { BIO_MAX_LENGTH, normalizeBio };

--- a/server/app/tests/mutations/presence/heartbeat.test.js
+++ b/server/app/tests/mutations/presence/heartbeat.test.js
@@ -1,0 +1,110 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import Presence from '~/resolvers/models/PresenceModel';
+import { pubsub } from '~/resolvers/subscriptions';
+import { heartbeat } from '~/resolvers/mutations/presence/heartbeat';
+
+// resolvers/subscriptions imports GRAPHQL_PORT from server.js, so importing it
+// for real pulls the whole server (and a require cycle) into the test. Stub it.
+// babel-plugin-jest-hoist lifts this above the imports at transform time.
+jest.mock('~/resolvers/subscriptions', () => ({
+  pubsub: { publish: jest.fn().mockResolvedValue(undefined) },
+}));
+
+const context = { user: { _id: 'user-1' } };
+
+/** Minimal stand-in for a Mongoose presence doc, with a spyable save(). */
+const presenceDoc = (overrides = {}) => ({
+  userId: { toString: () => 'user-1' },
+  status: 'online',
+  statusMessage: '',
+  preferredStatus: undefined,
+  preferredStatusMessage: '',
+  lastHeartbeat: new Date('2026-01-01T00:00:00Z'),
+  lastSeen: new Date('2026-01-01T00:00:00Z'),
+  save: sinon.stub().resolvesThis(),
+  ...overrides,
+});
+
+describe('Mutations > presence > heartbeat', () => {
+  let updateStub;
+
+  beforeEach(() => {
+    updateStub = sinon.stub(Presence, 'findOneAndUpdate');
+    pubsub.publish.mockClear();
+  });
+
+  afterEach(() => {
+    updateStub.restore();
+  });
+
+  it('requires authentication', async () => {
+    try {
+      await heartbeat(undefined, {}, {});
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect(error.message).to.equal('Authentication required');
+    }
+    sinon.assert.notCalled(updateStub);
+  });
+
+  it('returns the current status alongside success and timestamp', async () => {
+    const doc = presenceDoc({ status: 'away', statusMessage: 'In a meeting' });
+    updateStub.resolves(doc);
+
+    const result = await heartbeat(undefined, {}, context);
+
+    expect(result.success).to.equal(true);
+    expect(result.timestamp).to.equal(doc.lastHeartbeat);
+    expect(result.status).to.equal('away');
+    expect(result.statusMessage).to.equal('In a meeting');
+    sinon.assert.notCalled(doc.save);
+  });
+
+  // The cleanup job forces stale users offline. A heartbeat proves they are
+  // back, so their chosen status should be restored.
+  it('restores the preferred status when cleanup marked the user offline', async () => {
+    const doc = presenceDoc({
+      status: 'offline',
+      statusMessage: '',
+      preferredStatus: 'dnd',
+      preferredStatusMessage: 'Heads down',
+    });
+    updateStub.resolves(doc);
+
+    const result = await heartbeat(undefined, {}, context);
+
+    expect(result.status).to.equal('dnd');
+    expect(result.statusMessage).to.equal('Heads down');
+    sinon.assert.calledOnce(doc.save);
+    // Subscribers saw the offline event from cleanup; they need the return too.
+    expect(pubsub.publish.mock.calls).to.have.lengthOf(1);
+  });
+
+  it('does not announce an invisible user coming back', async () => {
+    const doc = presenceDoc({ status: 'offline', preferredStatus: 'invisible' });
+    updateStub.resolves(doc);
+
+    expect((await heartbeat(undefined, {}, context)).status).to.equal('invisible');
+    sinon.assert.calledOnce(doc.save);
+    expect(pubsub.publish.mock.calls).to.have.lengthOf(0);
+  });
+
+  it('falls back to online when the user never chose a status', async () => {
+    const doc = presenceDoc({ status: 'offline', preferredStatus: undefined });
+    updateStub.resolves(doc);
+
+    expect((await heartbeat(undefined, {}, context)).status).to.equal('online');
+    sinon.assert.calledOnce(doc.save);
+  });
+
+  // Choosing 'offline' is intent, not staleness — leave it alone, and do not
+  // write on every beat.
+  it('leaves a deliberately offline user offline', async () => {
+    const doc = presenceDoc({ status: 'offline', preferredStatus: 'offline' });
+    updateStub.resolves(doc);
+
+    expect((await heartbeat(undefined, {}, context)).status).to.equal('offline');
+    sinon.assert.notCalled(doc.save);
+  });
+});

--- a/server/app/tests/mutations/user/updateUser.test.js
+++ b/server/app/tests/mutations/user/updateUser.test.js
@@ -1,0 +1,64 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import UserModel from '~/resolvers/models/UserModel';
+import { updateUser } from '~/resolvers/mutations/user/updateUser';
+
+describe('Mutations > user > updateUser (bio)', () => {
+  let findOneStub;
+  let updateStub;
+
+  beforeEach(() => {
+    findOneStub = sinon.stub(UserModel, 'findOne');
+    updateStub = sinon.stub(UserModel, 'update').resolves();
+    // No username/email collisions in these cases; the final lookup returns
+    // whatever was persisted.
+    findOneStub.resolves(null);
+  });
+
+  afterEach(() => {
+    findOneStub.restore();
+    updateStub.restore();
+  });
+
+  /** The document handed to UserModel.update for the given input. */
+  const persistedFrom = async (user) => {
+    await updateUser()(undefined, { user });
+    return updateStub.firstCall.args[1];
+  };
+
+  it('trims bio before persisting', async () => {
+    const persisted = await persistedFrom({ _id: 'user-1', bio: '  hello  ' });
+    expect(persisted.bio).to.equal('hello');
+  });
+
+  it('rejects bio longer than the maximum length', async () => {
+    try {
+      await updateUser()(undefined, { user: { _id: 'user-1', bio: 'a'.repeat(501) } });
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect(error.message).to.contain('500 characters or fewer');
+    }
+    sinon.assert.notCalled(updateStub);
+  });
+
+  it('rejects bio containing HTML', async () => {
+    try {
+      await updateUser()(undefined, { user: { _id: 'user-1', bio: '<b>hi</b>' } });
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect(error.message).to.contain('plain text without HTML');
+    }
+    sinon.assert.notCalled(updateStub);
+  });
+
+  it('stores an empty string when bio is cleared', async () => {
+    const persisted = await persistedFrom({ _id: 'user-1', bio: '   ' });
+    expect(persisted.bio).to.equal('');
+  });
+
+  // Omitting bio must not blank an existing one — only an explicit value edits it.
+  it('leaves bio untouched when the field is not sent', async () => {
+    const persisted = await persistedFrom({ _id: 'user-1', name: 'New Name' });
+    expect(persisted).to.not.have.property('bio');
+  });
+});

--- a/server/app/tests/resolvers/userPresenceWiring.test.js
+++ b/server/app/tests/resolvers/userPresenceWiring.test.js
@@ -1,0 +1,52 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import PresenceModel from '~/resolvers/models/PresenceModel';
+import { resolvers } from '~/resolvers';
+
+// resolvers/subscriptions imports GRAPHQL_PORT from server.js; importing it for
+// real would boot Apollo and Mongo. See heartbeat.test.js for the same stub.
+jest.mock('~/resolvers/subscriptions', () => ({
+  pubsub: { publish: jest.fn().mockResolvedValue(undefined) },
+  Subscription: {},
+}));
+
+/**
+ * Regression guard: user_relationship was exported but never added to the
+ * resolver map, so its field resolvers never ran — User.reputation returns
+ * null in production because of it. A field resolver that is not wired fails
+ * silently, so assert the wiring itself, not just that the function exists.
+ */
+describe('resolvers > User field resolvers are wired', () => {
+  it('exposes User.presence in the resolver map', () => {
+    expect(resolvers.User).to.be.an('object');
+    expect(resolvers.User.presence).to.be.a('function');
+  });
+
+  describe('User.presence', () => {
+    let findOneStub;
+
+    beforeEach(() => {
+      findOneStub = sinon.stub(PresenceModel, 'findOne');
+    });
+
+    afterEach(() => {
+      findOneStub.restore();
+    });
+
+    it('looks up presence by the parent user id', async () => {
+      const doc = { userId: 'user-1', status: 'away' };
+      findOneStub.resolves(doc);
+
+      const result = await resolvers.User.presence({ _id: 'user-1' });
+
+      expect(result).to.equal(doc);
+      sinon.assert.calledWith(findOneStub, { userId: 'user-1' });
+    });
+
+    it('returns null instead of throwing when the lookup fails', async () => {
+      findOneStub.rejects(new Error('mongo is down'));
+
+      expect(await resolvers.User.presence({ _id: 'user-1' })).to.equal(null);
+    });
+  });
+});

--- a/server/app/tests/utils/bioValidation.test.js
+++ b/server/app/tests/utils/bioValidation.test.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import { normalizeBio, BIO_MAX_LENGTH } from '~/utils/bioValidation';
+
+describe('utils > bioValidation > normalizeBio', () => {
+  it('trims surrounding whitespace', () => {
+    expect(normalizeBio('  hello there  ')).to.equal('hello there');
+  });
+
+  it('returns an empty string for null and undefined', () => {
+    expect(normalizeBio(null)).to.equal('');
+    expect(normalizeBio(undefined)).to.equal('');
+  });
+
+  it('accepts text at exactly the maximum length', () => {
+    const atLimit = 'a'.repeat(BIO_MAX_LENGTH);
+    expect(normalizeBio(atLimit)).to.equal(atLimit);
+  });
+
+  it('rejects text longer than the maximum length', () => {
+    expect(() => normalizeBio('a'.repeat(BIO_MAX_LENGTH + 1)))
+      .to.throw(`About must be ${BIO_MAX_LENGTH} characters or fewer`);
+  });
+
+  it('measures length after trimming, so padding does not push it over', () => {
+    const padded = `  ${'a'.repeat(BIO_MAX_LENGTH)}  `;
+    expect(normalizeBio(padded)).to.have.lengthOf(BIO_MAX_LENGTH);
+  });
+
+  it('rejects HTML markup', () => {
+    expect(() => normalizeBio('<b>bold</b>')).to.throw('About must be plain text without HTML');
+    expect(() => normalizeBio('<script>alert(1)</script>')).to.throw('plain text without HTML');
+    expect(() => normalizeBio('<img src=x onerror=y>')).to.throw('plain text without HTML');
+  });
+
+  it('allows angle brackets that are not markup', () => {
+    expect(normalizeBio('a < b and c > d')).to.equal('a < b and c > d');
+  });
+
+  it('rejects non-string input', () => {
+    expect(() => normalizeBio(42)).to.throw('About must be text');
+    expect(() => normalizeBio({})).to.throw('About must be text');
+  });
+});

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -20,5 +20,11 @@ module.exports = {
     '!app/server.js',
   ],
   setupFilesAfterEnv: [],
+  // Importing the resolver barrel drags in dependencies that leave ~400 open
+  // handles (signal-exit and friends), so Jest hangs after a run instead of
+  // exiting — most visibly when running a single file. The leak is in
+  // third-party code and predates these tests; results are fully reported
+  // before this takes effect.
+  forceExit: true,
 };
 


### PR DESCRIPTION
## Summary

The production frontend ([`quotevote-next`](https://github.com/QuoteVote/quotevote-next)) has a built profile "About" feature and presence UI, but this backend exposed neither — those queries were rejected with HTTP 400 and the frontend code had to be removed in QuoteVote/quotevote-next#446.

This adds the missing fields so that work can be restored.

Refs #350. Unblocks QuoteVote/quotevote-next#362 (RC1-011).

**Every change is additive.** All 77 frontend GraphQL documents still validate against the modified schema.

## bio / About

- `bio` on `type User` and `input UserInput`, and on the Mongoose user model
- `normalizeBio()` in `utils/bioValidation.js` — trims, caps at 500 characters, rejects HTML, matching the frontend's `PROFILE_BIO_MAX_LENGTH` contract. Ported from the equivalent implementation in `quotevote-next/quotevote-backend/`.
- `updateUser` only touches `bio` when the client actually sends it, so omitting the field leaves an existing bio alone rather than silently clearing it

Existing users have no `bio` until they save one; the model defaults to `''`, so reads return empty rather than null. No migration needed.

## Presence

The frontend could not restore a user's status after a reload, because neither path it used carried the data.

- **`preferredStatus` / `preferredStatusMessage` on `Presence`**, recorded whenever a user chooses a status. The cleanup job forces `status` to `offline`; keeping intent separate means it is not erased.
- **`heartbeat` restores the preferred status** when cleanup had marked the user offline, and returns `status` / `statusMessage` so a client that just reloaded needs no second round trip.
  - A user who deliberately chose `offline` is left alone — that is intent, not staleness, and it also avoids a write on every beat.
  - Coming back publishes a `presenceEvent`, mirroring the offline event cleanup publishes, so buddy lists actually update. Invisible users are not announced.
- **`presence` on `type User`**, resolved on demand so user lists that omit the field are unaffected.

The last point was the open question in #350 — I went with `User.presence` because the field only resolves when selected and it saves the client a sequential second call. Happy to drop it and standardise on `getPresence(userId)` if you prefer.

## Typing

`TypingResponse` echoes `messageRoomId` and `isTyping`, so a client with several open rooms can correlate a response to the request that produced it.

## Wiring fix — worth a look

`user_relationship` was exported but **never added to the resolver map** in `resolvers/index.js`, so its field resolvers have never run. Confirmed against production:

```
query { user(username: "louisgirifalco") { reputation { overallScore } } }
→ { "reputation": null }
```

`User.reputation` is in the schema and the frontend queries it, but it returns null for every user today.

Without fixing this, the new `presence` field would have silently returned null too — a field resolver that is not wired fails quietly, and unit tests that call the function directly still pass. There is now a regression test asserting the wiring itself.

**Only `presence` is wired here.** Enabling `reputation` would start running `ReputationCalculator` on every user query — a performance change that deserves its own review. Worth a separate issue.

## Testing

22 new cases across bio validation, `updateUser`'s bio handling, the heartbeat restore paths, and the resolver wiring.

**Each was verified against a mutated implementation** to confirm it actually fails when the behaviour regresses:

| Mutation | Result |
|---|---|
| heartbeat stops restoring preferred status | 2 failed |
| heartbeat flips a deliberately-offline user | 1 failed |
| `updateUser` stops validating bio | 4 failed |
| bio length cap removed | 1 failed |

- `npm run test --workspace=server` — **44 passing**, 11 suites (up from 22 / 7 on `main`)
- `npm run build:server` — compiles 265 files
- All 77 frontend documents validate against the modified schema
- Lint: 1090 problems vs 1086 on `main` — the four extra are the `~/` alias and `_id` patterns every existing test file already has

Presence and typing resolvers had no unit tests at all, and it is structural: `resolvers/subscriptions` imports `GRAPHQL_PORT` from `server.js`, so importing any pubsub-using resolver drags the whole server into the test. These suites mock that module rather than reshaping production code. The underlying cycle is worth its own cleanup — `import/no-cycle` already fires on `updatePresence.js` on `main`.

## One shared-config change

`jest.config.js` now sets `forceExit`. Importing the resolver barrel drags in dependencies that leave ~400 open handles (`signal-exit` and friends), so Jest hung after a run instead of exiting — most visibly when running a single file (exit 124 after 90s). The leak is third-party and predates this work; results are fully reported before `forceExit` takes effect. Single file now exits in 1s, full suite in 3s.

Flagging it explicitly since it affects everyone — happy to drop it and leave the hang if you would rather not mask the leak.

## Follow-up on the frontend

After this deploys, `quotevote-next` needs `pnpm schema:update` to refresh its committed schema snapshot, then the About field and presence restore can be put back. I would keep that as a separate frontend PR so a rollback here never leaves the frontend querying fields that vanished.
