### PR TITLE
feat(api): paginate notifications, add updateComment/deleteActionReaction/latestQuotes

### DIFF
--- a/server/app/data/resolvers/mutations.js
+++ b/server/app/data/resolvers/mutations.js
@@ -23,6 +23,7 @@ export const resolver_mutations = function () {
     updateFeaturedSlot: postMutations.updateFeaturedSlot(),
     addActionReaction: postMutations.addActionReactions(),
     updateActionReaction: postMutations.updateActionReaction(),
+    deleteActionReaction: postMutations.deleteActionReaction(),
     reportPost: postMutations.reportPost(),
     deletePost: postMutations.deletePost(),
     toggleVoting: postMutations.toggleVoting(),
@@ -37,6 +38,7 @@ export const resolver_mutations = function () {
     // Comment mutations
     addComment: commentMutations.addComment(),
     deleteComment: commentMutations.deleteComment(),
+    updateComment: commentMutations.updateComment(),
 
     // Quote mutation
     addQuote: quoteMutations.addQuote(),

--- a/server/app/data/resolvers/mutations/comment/index.js
+++ b/server/app/data/resolvers/mutations/comment/index.js
@@ -1,2 +1,3 @@
 export * from './addComment';
 export * from './editComment';
+export * from './updateComment';

--- a/server/app/data/resolvers/mutations/comment/updateComment.js
+++ b/server/app/data/resolvers/mutations/comment/updateComment.js
@@ -1,0 +1,48 @@
+import { logger } from '../../../utils/logger';
+import CommentsModel from '../../models/CommentModel';
+
+/**
+ * Edit the text of an existing comment.
+ *
+ * Deliberately narrower than editComment (which is unexposed): only `content`
+ * changes, the caller must own the comment or be an admin, and there is no
+ * upsert — editing a comment must never create one.
+ */
+export const updateComment = () => {
+  return async (_, args, context) => {
+    logger.info('Function: updateComment');
+
+    const { commentId, content } = args;
+    const { user } = context;
+
+    if (!user) {
+      throw new Error('Authentication required');
+    }
+
+    const trimmed = typeof content === 'string' ? content.trim() : '';
+    if (!trimmed) {
+      throw new Error('Comment content is required');
+    }
+
+    const comment = await CommentsModel.findById(commentId);
+    if (!comment) {
+      throw new Error('Comment not found');
+    }
+
+    if (comment.deleted) {
+      throw new Error('Cannot edit a deleted comment');
+    }
+
+    if (comment.userId.toString() !== user._id.toString() && !user.admin) {
+      throw new Error('Not authorized to edit this comment');
+    }
+
+    // Only `content` is touched — CommentModel has no edited/updated fields,
+    // and setting unknown keys would be silently dropped by Mongoose.
+    return CommentsModel.findByIdAndUpdate(
+      commentId,
+      { $set: { content: trimmed } },
+      { new: true },
+    );
+  };
+};

--- a/server/app/data/resolvers/mutations/post/deleteActionReaction.js
+++ b/server/app/data/resolvers/mutations/post/deleteActionReaction.js
@@ -1,0 +1,34 @@
+import ReactionModel from '../../models/ReactionModel';
+import { logger } from '../../../utils/logger';
+
+/**
+ * Remove a reaction the caller previously added.
+ *
+ * Reactions could be added and changed but never removed. Only the author of
+ * a reaction (or an admin) may delete it.
+ */
+export const deleteActionReaction = () => {
+  return async (_, args, context) => {
+    const { _id } = args;
+    const { user } = context;
+
+    logger.debug('[MUTATION] deleteActionReaction', { reactionId: _id, userId: user?._id });
+
+    if (!user) {
+      throw new Error('Authentication required');
+    }
+
+    const reaction = await ReactionModel.findById(_id);
+    if (!reaction) {
+      // Already gone — deleting twice is not an error.
+      return true;
+    }
+
+    if (reaction.userId.toString() !== user._id.toString() && !user.admin) {
+      throw new Error('Not authorized to delete this reaction');
+    }
+
+    await ReactionModel.deleteOne({ _id });
+    return true;
+  };
+};

--- a/server/app/data/resolvers/mutations/post/index.js
+++ b/server/app/data/resolvers/mutations/post/index.js
@@ -4,6 +4,7 @@ export * from './rejectPost';
 export * from './updatePostBookmark';
 export * from './addActionReactions';
 export * from './updateActionReaction';
+export * from './deleteActionReaction';
 export * from './reportPost';
 export * from './deletePost';
 export * from './updateFeaturedSlot';

--- a/server/app/data/resolvers/queries.js
+++ b/server/app/data/resolvers/queries.js
@@ -4,6 +4,7 @@ import * as groupQuery from './queries/group';
 import * as messageQuery from './queries/message';
 import * as userQuery from './queries/user';
 import * as notificationQuery from './queries/notification';
+import * as quoteQuery from './queries/quote';
 import * as presenceQuery from './queries/presence';
 import * as typingQuery from './queries/typing';
 import * as contentQuery from './queries/content';
@@ -37,6 +38,7 @@ export const resolver_query = function () {
     messageRoom: messageQuery.getUserChatRoom(),
     notifications: notificationQuery.getNotifications(),
     messageReactions: messageQuery.getUserMessageReactions(),
+    latestQuotes: quoteQuery.latestQuotes(),
 
     // Presence queries
     getPresence: presenceQuery.getPresence,

--- a/server/app/data/resolvers/queries/activity/getUserActivities.js
+++ b/server/app/data/resolvers/queries/activity/getUserActivities.js
@@ -19,7 +19,13 @@ export const getUserActivities = (pubsub) => {
     if (activityEvent) {
       try {
         const parsedActivityEvent = typeof activityEvent === 'string' ? JSON.parse(activityEvent) : activityEvent;
-        searchArgs.activityType = { $in: parsedActivityEvent };
+        // An empty list means "no filter", not "match nothing". `[]` is truthy,
+        // so without this guard $in: [] silently returned an empty feed.
+        if (Array.isArray(parsedActivityEvent) && parsedActivityEvent.length === 0) {
+          logger.debug('activityEvent is empty — not filtering by activity type');
+        } else {
+          searchArgs.activityType = { $in: parsedActivityEvent };
+        }
       } catch (error) {
         logger.error('Error parsing activityEvent', { error: error.message, stack: error.stack, activityEvent });
       }

--- a/server/app/data/resolvers/queries/notification/getNotifications.js
+++ b/server/app/data/resolvers/queries/notification/getNotifications.js
@@ -1,11 +1,42 @@
 import NotificationsModel from '../../models/NotificationModel';
 
+/** Applied when the caller does not ask for a specific page size. */
+export const DEFAULT_NOTIFICATION_LIMIT = 50;
+
+/** Upper bound, so a client cannot ask for an unbounded result set. */
+export const MAX_NOTIFICATION_LIMIT = 100;
+
+/**
+ * Clamp a caller-supplied limit into [1, MAX_NOTIFICATION_LIMIT].
+ * Anything missing or nonsensical falls back to the default.
+ */
+export const resolveLimit = (limit) => {
+  if (limit === null || limit === undefined) {
+    return DEFAULT_NOTIFICATION_LIMIT;
+  }
+  if (!Number.isFinite(limit) || limit < 1) {
+    return DEFAULT_NOTIFICATION_LIMIT;
+  }
+  return Math.min(Math.trunc(limit), MAX_NOTIFICATION_LIMIT);
+};
+
 export const getNotifications = (pubsub) => {
   return async (_, args, context) => {
     const contextUserId = context.user._id;
-    return await NotificationsModel.find({
+    const { limit, offset, status } = args || {};
+
+    const query = {
       userId: contextUserId,
-      status: 'new',
-    }).sort({ created: 'desc' });
+      // 'new' preserves the previous behaviour; pass status: null for all.
+      status: status === undefined ? 'new' : status,
+    };
+    if (query.status === null) {
+      delete query.status;
+    }
+
+    return NotificationsModel.find(query)
+      .sort({ created: 'desc' })
+      .skip(Number.isFinite(offset) && offset > 0 ? Math.trunc(offset) : 0)
+      .limit(resolveLimit(limit));
   };
 };

--- a/server/app/data/resolvers/queries/quote/index.js
+++ b/server/app/data/resolvers/queries/quote/index.js
@@ -1,0 +1,1 @@
+export * from './latestQuotes';

--- a/server/app/data/resolvers/queries/quote/latestQuotes.js
+++ b/server/app/data/resolvers/queries/quote/latestQuotes.js
@@ -1,0 +1,20 @@
+import QuoteModel from '../../models/QuoteModel';
+import { logger } from '../../../utils/logger';
+
+/** Upper bound so a client cannot ask for an unbounded result set. */
+export const MAX_LATEST_QUOTES = 100;
+
+export const latestQuotes = () => {
+  return async (_, args) => {
+    const { limit } = args;
+    logger.debug('Function: latestQuotes', { limit });
+
+    const capped = Number.isFinite(limit) && limit > 0
+      ? Math.min(Math.trunc(limit), MAX_LATEST_QUOTES)
+      : MAX_LATEST_QUOTES;
+
+    return QuoteModel.find({ deleted: { $ne: true } })
+      .sort({ created: 'desc' })
+      .limit(capped);
+  };
+};

--- a/server/app/data/type_definition/mutation_definition.js
+++ b/server/app/data/type_definition/mutation_definition.js
@@ -31,6 +31,9 @@ export const Mutation = `type Mutation {
   # Mutation for deleting a comment
   deleteComment(commentId: String!): DeletedComment
 
+  # Mutation for editing a comment's text. Author or admin only.
+  updateComment(commentId: String!, content: String!): Comment
+
   # Mutation for creating new quote
   addQuote(quote: QuoteInput!): Quote
 
@@ -90,6 +93,9 @@ export const Mutation = `type Mutation {
 
   # Mutation for updating an action reaction
     updateActionReaction(_id: String! emoji: String!): Reaction
+
+  # Mutation for removing an action reaction. Author or admin only.
+    deleteActionReaction(_id: String!): Boolean!
 
   # Mutation for reporting a post
     reportPost(postId: String!, userId: String!): Post

--- a/server/app/data/type_definition/query_definition.js
+++ b/server/app/data/type_definition/query_definition.js
@@ -67,8 +67,11 @@ type Query {
   " This will query user info if token is valid"
   verifyUserPasswordResetToken(token: String!): JSON
   
-  " This will query user notifications"
-  notifications: [Notification]
+  " This will query user notifications. limit defaults to 50 and is capped at 100; status defaults to 'new' "
+  notifications(limit: Int, offset: Int, status: String): [Notification]
+
+  " Most recently created quotes, newest first. limit is capped at 100 "
+  latestQuotes(limit: Int!): [Quote]
 
   " This will query the message Reactions"
   messageReactions(messageId: String!): [Reaction]

--- a/server/app/tests/mutations/comment/updateComment.test.js
+++ b/server/app/tests/mutations/comment/updateComment.test.js
@@ -1,0 +1,86 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import CommentsModel from '~/resolvers/models/CommentModel';
+import { updateComment } from '~/resolvers/mutations/comment/updateComment';
+
+const owner = { user: { _id: 'user-1' } };
+const stranger = { user: { _id: 'user-2' } };
+const admin = { user: { _id: 'user-2', admin: true } };
+
+const existing = (overrides = {}) => ({
+  _id: 'comment-1',
+  userId: { toString: () => 'user-1' },
+  content: 'original',
+  deleted: false,
+  ...overrides,
+});
+
+describe('Mutations > comment > updateComment', () => {
+  let findByIdStub;
+  let updateStub;
+
+  beforeEach(() => {
+    findByIdStub = sinon.stub(CommentsModel, 'findById');
+    updateStub = sinon.stub(CommentsModel, 'findByIdAndUpdate').resolves({ _id: 'comment-1' });
+  });
+
+  afterEach(() => {
+    findByIdStub.restore();
+    updateStub.restore();
+  });
+
+  const expectRejection = async (args, context, message) => {
+    try {
+      await updateComment()(undefined, args, context);
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect(error.message).to.contain(message);
+    }
+    sinon.assert.notCalled(updateStub);
+  };
+
+  it('requires authentication', async () => {
+    await expectRejection({ commentId: 'comment-1', content: 'edited' }, {}, 'Authentication required');
+  });
+
+  it('lets the author edit their own comment', async () => {
+    findByIdStub.resolves(existing());
+
+    await updateComment()(undefined, { commentId: 'comment-1', content: '  edited  ' }, owner);
+
+    // Only content changes, and it is trimmed.
+    sinon.assert.calledWith(updateStub, 'comment-1', { $set: { content: 'edited' } }, { new: true });
+  });
+
+  it('lets an admin edit anyone\'s comment', async () => {
+    findByIdStub.resolves(existing());
+
+    await updateComment()(undefined, { commentId: 'comment-1', content: 'edited' }, admin);
+
+    sinon.assert.called(updateStub);
+  });
+
+  it('refuses a user editing someone else\'s comment', async () => {
+    findByIdStub.resolves(existing());
+    await expectRejection(
+      { commentId: 'comment-1', content: 'edited' }, stranger, 'Not authorized',
+    );
+  });
+
+  it('refuses empty or whitespace-only content', async () => {
+    findByIdStub.resolves(existing());
+    await expectRejection({ commentId: 'comment-1', content: '   ' }, owner, 'content is required');
+  });
+
+  it('refuses editing a deleted comment', async () => {
+    findByIdStub.resolves(existing({ deleted: true }));
+    await expectRejection({ commentId: 'comment-1', content: 'edited' }, owner, 'deleted comment');
+  });
+
+  // editComment (unexposed) used upsert:true, which would create a comment
+  // from an arbitrary id. Editing must never create.
+  it('refuses a comment that does not exist, rather than creating one', async () => {
+    findByIdStub.resolves(null);
+    await expectRejection({ commentId: 'nope', content: 'edited' }, owner, 'not found');
+  });
+});

--- a/server/app/tests/mutations/post/deleteActionReaction.test.js
+++ b/server/app/tests/mutations/post/deleteActionReaction.test.js
@@ -1,0 +1,73 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import ReactionModel from '~/resolvers/models/ReactionModel';
+import { deleteActionReaction } from '~/resolvers/mutations/post/deleteActionReaction';
+
+const owner = { user: { _id: 'user-1' } };
+const stranger = { user: { _id: 'user-2' } };
+const admin = { user: { _id: 'user-2', admin: true } };
+
+const reaction = () => ({
+  _id: 'reaction-1',
+  userId: { toString: () => 'user-1' },
+  emoji: '👍',
+});
+
+describe('Mutations > post > deleteActionReaction', () => {
+  let findByIdStub;
+  let deleteOneStub;
+
+  beforeEach(() => {
+    findByIdStub = sinon.stub(ReactionModel, 'findById');
+    deleteOneStub = sinon.stub(ReactionModel, 'deleteOne').resolves();
+  });
+
+  afterEach(() => {
+    findByIdStub.restore();
+    deleteOneStub.restore();
+  });
+
+  it('requires authentication', async () => {
+    try {
+      await deleteActionReaction()(undefined, { _id: 'reaction-1' }, {});
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect(error.message).to.contain('Authentication required');
+    }
+    sinon.assert.notCalled(deleteOneStub);
+  });
+
+  it('lets the author delete their own reaction', async () => {
+    findByIdStub.resolves(reaction());
+
+    expect(await deleteActionReaction()(undefined, { _id: 'reaction-1' }, owner)).to.equal(true);
+    sinon.assert.calledWith(deleteOneStub, { _id: 'reaction-1' });
+  });
+
+  it('lets an admin delete any reaction', async () => {
+    findByIdStub.resolves(reaction());
+
+    expect(await deleteActionReaction()(undefined, { _id: 'reaction-1' }, admin)).to.equal(true);
+    sinon.assert.called(deleteOneStub);
+  });
+
+  it('refuses deleting someone else\'s reaction', async () => {
+    findByIdStub.resolves(reaction());
+
+    try {
+      await deleteActionReaction()(undefined, { _id: 'reaction-1' }, stranger);
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect(error.message).to.contain('Not authorized');
+    }
+    sinon.assert.notCalled(deleteOneStub);
+  });
+
+  // Deleting twice is a no-op, not an error — the desired end state is reached.
+  it('is idempotent when the reaction is already gone', async () => {
+    findByIdStub.resolves(null);
+
+    expect(await deleteActionReaction()(undefined, { _id: 'gone' }, owner)).to.equal(true);
+    sinon.assert.notCalled(deleteOneStub);
+  });
+});

--- a/server/app/tests/queries/activity/getUserActivities.test.js
+++ b/server/app/tests/queries/activity/getUserActivities.test.js
@@ -1,0 +1,63 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import ActivityModel from '~/resolvers/models/ActivityModel';
+import { getUserActivities } from '~/resolvers/queries/activity/getUserActivities';
+
+const context = { user: { _id: 'user-1' } };
+
+describe('Queries > activity > getUserActivities (activityEvent filter)', () => {
+  let findStub;
+
+  beforeEach(() => {
+    // count() on the first call, the chain on the second.
+    findStub = sinon.stub(ActivityModel, 'find');
+    findStub.onFirstCall().returns({ count: sinon.stub().resolves(0) });
+    findStub.onSecondCall().returns({
+      sort: sinon.stub().returnsThis(),
+      skip: sinon.stub().returnsThis(),
+      limit: sinon.stub().resolves([]),
+    });
+  });
+
+  afterEach(() => {
+    findStub.restore();
+  });
+
+  /** The Mongo query built for the given args. */
+  const searchArgsFor = async (args) => {
+    await getUserActivities()(undefined, { user_id: 'user-1', ...args }, context);
+    return findStub.firstCall.args[0];
+  };
+
+  it('filters by the requested activity types', async () => {
+    const searchArgs = await searchArgsFor({ activityEvent: ['POSTED', 'VOTED'] });
+
+    expect(searchArgs.activityType).to.deep.equal({ $in: ['POSTED', 'VOTED'] });
+  });
+
+  // `[]` is truthy, so this previously became $in: [] and matched nothing —
+  // an empty filter silently returned an empty feed.
+  it('treats an empty list as no filter rather than matching nothing', async () => {
+    const searchArgs = await searchArgsFor({ activityEvent: [] });
+
+    expect(searchArgs).to.not.have.property('activityType');
+  });
+
+  it('applies no filter when activityEvent is omitted', async () => {
+    const searchArgs = await searchArgsFor({});
+
+    expect(searchArgs).to.not.have.property('activityType');
+  });
+
+  it('still accepts a JSON-encoded array for older clients', async () => {
+    const searchArgs = await searchArgsFor({ activityEvent: '["COMMENTED"]' });
+
+    expect(searchArgs.activityType).to.deep.equal({ $in: ['COMMENTED'] });
+  });
+
+  it('treats a JSON-encoded empty array as no filter too', async () => {
+    const searchArgs = await searchArgsFor({ activityEvent: '[]' });
+
+    expect(searchArgs).to.not.have.property('activityType');
+  });
+});

--- a/server/app/tests/queries/notification/getNotifications.test.js
+++ b/server/app/tests/queries/notification/getNotifications.test.js
@@ -1,0 +1,91 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import NotificationsModel from '~/resolvers/models/NotificationModel';
+import {
+  getNotifications,
+  resolveLimit,
+  DEFAULT_NOTIFICATION_LIMIT,
+  MAX_NOTIFICATION_LIMIT,
+} from '~/resolvers/queries/notification/getNotifications';
+
+const context = { user: { _id: 'user-1' } };
+
+describe('Queries > notification > resolveLimit', () => {
+  it('defaults when no limit is supplied', () => {
+    expect(resolveLimit(undefined)).to.equal(DEFAULT_NOTIFICATION_LIMIT);
+    expect(resolveLimit(null)).to.equal(DEFAULT_NOTIFICATION_LIMIT);
+  });
+
+  it('caps oversized requests', () => {
+    expect(resolveLimit(5000)).to.equal(MAX_NOTIFICATION_LIMIT);
+  });
+
+  it('passes through a sensible limit', () => {
+    expect(resolveLimit(10)).to.equal(10);
+  });
+
+  it('falls back for zero, negatives and nonsense', () => {
+    expect(resolveLimit(0)).to.equal(DEFAULT_NOTIFICATION_LIMIT);
+    expect(resolveLimit(-5)).to.equal(DEFAULT_NOTIFICATION_LIMIT);
+    expect(resolveLimit(NaN)).to.equal(DEFAULT_NOTIFICATION_LIMIT);
+  });
+});
+
+describe('Queries > notification > getNotifications', () => {
+  let findStub;
+  let chain;
+
+  beforeEach(() => {
+    chain = {
+      sort: sinon.stub().returnsThis(),
+      skip: sinon.stub().returnsThis(),
+      limit: sinon.stub().resolves([]),
+    };
+    findStub = sinon.stub(NotificationsModel, 'find').returns(chain);
+  });
+
+  afterEach(() => {
+    findStub.restore();
+  });
+
+  it('scopes to the authenticated user and defaults to new notifications', async () => {
+    await getNotifications()(undefined, {}, context);
+
+    sinon.assert.calledWith(findStub, { userId: 'user-1', status: 'new' });
+    sinon.assert.calledWith(chain.limit, DEFAULT_NOTIFICATION_LIMIT);
+    sinon.assert.calledWith(chain.skip, 0);
+  });
+
+  it('applies limit and offset', async () => {
+    await getNotifications()(undefined, { limit: 10, offset: 20 }, context);
+
+    sinon.assert.calledWith(chain.limit, 10);
+    sinon.assert.calledWith(chain.skip, 20);
+  });
+
+  // Previously every caller fetched the entire history; a client asking for
+  // more than the cap must not be able to.
+  it('caps an oversized limit', async () => {
+    await getNotifications()(undefined, { limit: 100000 }, context);
+
+    sinon.assert.calledWith(chain.limit, MAX_NOTIFICATION_LIMIT);
+  });
+
+  it('filters by an explicit status', async () => {
+    await getNotifications()(undefined, { status: 'read' }, context);
+
+    sinon.assert.calledWith(findStub, { userId: 'user-1', status: 'read' });
+  });
+
+  it('returns every status when status is null', async () => {
+    await getNotifications()(undefined, { status: null }, context);
+
+    sinon.assert.calledWith(findStub, { userId: 'user-1' });
+  });
+
+  it('ignores a negative offset', async () => {
+    await getNotifications()(undefined, { offset: -10 }, context);
+
+    sinon.assert.calledWith(chain.skip, 0);
+  });
+});

--- a/server/app/tests/queries/quote/latestQuotes.test.js
+++ b/server/app/tests/queries/quote/latestQuotes.test.js
@@ -1,0 +1,51 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import QuoteModel from '~/resolvers/models/QuoteModel';
+import { latestQuotes, MAX_LATEST_QUOTES } from '~/resolvers/queries/quote/latestQuotes';
+
+describe('Queries > quote > latestQuotes', () => {
+  let findStub;
+  let chain;
+
+  beforeEach(() => {
+    chain = {
+      sort: sinon.stub().returnsThis(),
+      limit: sinon.stub().resolves([]),
+    };
+    findStub = sinon.stub(QuoteModel, 'find').returns(chain);
+  });
+
+  afterEach(() => {
+    findStub.restore();
+  });
+
+  it('returns the newest quotes first and excludes deleted ones', async () => {
+    await latestQuotes()(undefined, { limit: 5 });
+
+    sinon.assert.calledWith(findStub, { deleted: { $ne: true } });
+    sinon.assert.calledWith(chain.sort, { created: 'desc' });
+    sinon.assert.calledWith(chain.limit, 5);
+  });
+
+  it('caps an oversized limit', async () => {
+    await latestQuotes()(undefined, { limit: 10000 });
+
+    sinon.assert.calledWith(chain.limit, MAX_LATEST_QUOTES);
+  });
+
+  it('falls back to the cap for a missing or nonsensical limit', async () => {
+    await latestQuotes()(undefined, { limit: 0 });
+    sinon.assert.calledWith(chain.limit, MAX_LATEST_QUOTES);
+
+    await latestQuotes()(undefined, {});
+    sinon.assert.calledWith(chain.limit, MAX_LATEST_QUOTES);
+  });
+
+  it('returns whatever the query resolves to', async () => {
+    chain.limit.resolves([{ _id: 'quote-1', quote: 'hello' }]);
+
+    const result = await latestQuotes()(undefined, { limit: 1 });
+
+    expect(result).to.deep.equal([{ _id: 'quote-1', quote: 'hello' }]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the additive gaps in #351 — capabilities the production frontend ([`quotevote-next`](https://github.com/QuoteVote/quotevote-next)) needs that this API did not expose.

**Every change is additive.** All 77 frontend GraphQL documents still validate against the modified schema.

Refs #351.

## Changes

### `notifications(limit, offset, status)`

Previously took **no arguments at all**, so every client fetched the entire notification history and sliced it locally. The dashboard polls this every 60 seconds for every logged-in user, so the cost grew without bound as a user accumulated notifications.

- `limit` defaults to 50, capped at 100
- `offset` for pagination; negatives are ignored
- `status` defaults to `'new'` (previous behaviour); pass `null` to get every status

### `updateComment(commentId: String!, content: String!): Comment`

Comments could be added and deleted but never edited.

An unexposed `editComment` resolver already existed, but **it is not safe to expose**: no authentication check, and `upsert: true`, so it would create a comment from an arbitrary id. This is a deliberately narrower replacement:

- author-or-admin only
- `content` only, trimmed, and rejected when empty
- no upsert — editing must never create
- refuses deleted or missing comments

`editComment` is left untouched and still unexposed.

### `deleteActionReaction(_id: String!): Boolean!`

Reactions could be added (`addActionReaction`) and changed (`updateActionReaction`) but never removed.

- author-or-admin only
- idempotent: deleting an already-gone reaction returns `true` rather than erroring, since the desired end state is reached either way

### `latestQuotes(limit: Int!): [Quote]`

`Query` exposed no quote field at all. Returns newest first, excludes deleted quotes, caps `limit` at 100.

### Activity filter bug

`getUserActivities` did `if (activityEvent) { searchArgs.activityType = { $in: parsed } }`. Since `[]` is truthy, an empty list became `$in: []` and matched nothing — **an empty filter silently returned an empty feed**. It now means "no filter", for both array and JSON-encoded-string callers.

## Deferred — these two would break the deployed frontend

#351 also asks for a typed `ActivityEventType` enum and a `MutationResult` payload. Both are type **changes** rather than additions, and both break the currently deployed frontend. I verified rather than assumed, by building a schema with those changes applied and validating the frontend documents against it:

```
✗ GET_USER_ACTIVITY: Variable "$activityEvent" of type "JSON" used in position
                     expecting type "[ActivityEventType!]".
✗ SEND_USER_INVITE:  Field "sendUserInvite" of type "MutationResult" must have
                     a selection of subfields.
✗ REPORT_USER:       Field "reportUser" of type "MutationResult" must have a
                     selection of subfields.
```

The frontend declares `$activityEvent: JSON` and selects no subfields on those two mutations — both correct against today's schema, both invalid against the proposed one.

These need a coordinated release (backend accepting both shapes first, or a simultaneous deploy), not a unilateral backend change. Worth their own issue.

## Testing

31 new cases. **Each was checked against a mutated implementation** to confirm it actually fails when the behaviour regresses:

| Mutation | Result |
|---|---|
| notifications limit cap removed | 2 failed |
| `updateComment` ownership check removed | 1 failed |
| `deleteActionReaction` ownership check removed | 1 failed |
| empty-array guard removed (the original bug) | 2 failed |
| `latestQuotes` stops excluding deleted | 1 failed |

- `npm run test --workspace=server` — **53 passing**, 12 suites (up from 22 / 7 on `main`)
- `npm run build:server` — compiles 268 files
- All 77 frontend documents validate against the modified schema
- Lint: 1090 problems vs 1067 on `main`. The +23 are all established house-pattern categories — `~/` alias resolution (`import/no-unresolved`, `import/extensions`), `_id` (`no-underscore-dangle`), and `prefer-default-export`, all of which existing files such as `heartbeat.js` and `getUserReputation.js` already trip.

## Follow-up on the frontend

After this deploys, `quotevote-next` needs `pnpm schema:update` to refresh its committed schema snapshot. `GET_NOTIFICATIONS` can then take a `limit` again, and `GET_LATEST_QUOTES` / `UPDATE_COMMENT` / `DELETE_ACTION_REACTION` — deleted in QuoteVote/quotevote-next#446 — can be restored. Best kept as a separate frontend PR so a rollback here never leaves the frontend querying fields that vanished.
