### PR TITLE
fix(auth): gate GraphQL operations by parsed root field, not substring

### DIFF
--- a/server/app/data/resolvers/queries/user/findUserById.js
+++ b/server/app/data/resolvers/queries/user/findUserById.js
@@ -1,4 +1,5 @@
 import { isUndefined } from 'lodash';
+import { AuthenticationError } from 'apollo-server-express';
 import UserModel from '../../models/UserModel';
 import VotesModel from '../../models/VoteModel';
 import * as utils from '../../utils';
@@ -18,6 +19,12 @@ export const findUserById = () => {
         const { ObjectId } = require('mongodb');
         user = await UserModel.findOne({ creatorId: new ObjectId(args.creatorId) });
       } else {
+        // No identifying argument: fall back to "me". Guard the context so an
+        // anonymous caller gets a clean auth error instead of a TypeError on
+        // user._id, which surfaced to clients as HTTP 200 + INTERNAL_SERVER_ERROR.
+        if (!context || !context.user || !context.user._id) {
+          throw new AuthenticationError('Authentication required');
+        }
         userId = context.user._id;
         user = await UserModel.findOne({ _id: userId });
       }

--- a/server/app/data/utils/requireAuth.js
+++ b/server/app/data/utils/requireAuth.js
@@ -1,6 +1,16 @@
+import { parse } from 'graphql';
 import { logger } from './logger';
 
-const PUBLIC_QUERIES = [
+/**
+ * Root fields that may be executed without a token.
+ *
+ * These are matched by *exact field name*. The previous implementation tested
+ * `query.includes(publicName)` against the whole document, so any operation
+ * that merely mentioned "post", "user", "group" or "messages" anywhere — a
+ * `userId` field, a nested `post { _id }` selection — skipped the gate. In
+ * practice almost nothing was gated.
+ */
+const PUBLIC_OPERATIONS = new Set([
   'addStripeCustomer',
   'requestUserAccess',
   'checkDuplicateEmail',
@@ -13,7 +23,6 @@ const PUBLIC_QUERIES = [
   'featuredPosts',
   'post',
   'topPosts',
-  'featuredPosts',
   'messages',
   'actionReactions',
   'messageReactions',
@@ -21,20 +30,94 @@ const PUBLIC_QUERIES = [
   'getUserFollowInfo',
   'group',
   'groups',
-  // add more public queries/mutations
-];
+  // Public search on the landing page. The resolver excludes hash_password,
+  // reset tokens, wallet and email, and caps results at 50.
+  'searchUser',
+]);
 
-const requireAuth = (query) => {
-  let requireAuth = true;
-  for (const publicQuery of PUBLIC_QUERIES) {
-    const isFound = query.includes(publicQuery);
-    if (isFound) {
-      requireAuth = false;
-      break;
+/** Introspection fields are handled here as well as by the server context. */
+const isIntrospectionField = (name) => name.startsWith('__');
+
+/**
+ * Collect the root field names of every operation in a document.
+ *
+ * Root selections may be fragment spreads, so named fragments are resolved
+ * one level (fragments on Query/Mutation). Returns null when the document
+ * cannot be parsed or contains no operation, so callers can fail closed.
+ */
+export const getRootFieldNames = (query) => {
+  let document;
+  try {
+    document = parse(query);
+  } catch (error) {
+    logger.debug('requireAuth could not parse query', { error: error.message });
+    return null;
+  }
+
+  const fragments = new Map();
+  for (const def of document.definitions) {
+    if (def.kind === 'FragmentDefinition') {
+      fragments.set(def.name.value, def);
     }
   }
-  logger.debug('requireAuth check', { requireAuth, query });
-  return requireAuth;
+
+  const names = [];
+  const collect = (selectionSet, depth = 0) => {
+    if (!selectionSet || depth > 5) return;
+    for (const selection of selectionSet.selections) {
+      if (selection.kind === 'Field') {
+        names.push(selection.name.value);
+      } else if (selection.kind === 'InlineFragment') {
+        collect(selection.selectionSet, depth + 1);
+      } else if (selection.kind === 'FragmentSpread') {
+        const fragment = fragments.get(selection.name.value);
+        if (fragment) collect(fragment.selectionSet, depth + 1);
+      }
+    }
+  };
+
+  let sawOperation = false;
+  for (const def of document.definitions) {
+    if (def.kind === 'OperationDefinition') {
+      sawOperation = true;
+      collect(def.selectionSet);
+    }
+  }
+
+  if (!sawOperation) return null;
+  return names;
 };
 
+/**
+ * Whether a GraphQL document requires an authenticated user.
+ *
+ * Denies by default: an unparseable document, one with no operation, or one
+ * containing any root field outside the allowlist requires authentication.
+ */
+const requireAuth = (query) => {
+  if (!query || typeof query !== 'string') {
+    return true;
+  }
+
+  const rootFields = getRootFieldNames(query);
+
+  if (rootFields === null || rootFields.length === 0) {
+    logger.debug('requireAuth check', { requireAuth: true, reason: 'no parseable operation' });
+    return true;
+  }
+
+  const gated = rootFields.filter(
+    (name) => !PUBLIC_OPERATIONS.has(name) && !isIntrospectionField(name),
+  );
+
+  if (gated.length > 0) {
+    logger.debug('requireAuth check', { requireAuth: true, gated });
+    return true;
+  }
+
+  logger.debug('requireAuth check', { requireAuth: false, rootFields });
+  return false;
+};
+
+export { PUBLIC_OPERATIONS };
 export default requireAuth;

--- a/server/app/tests/queries/user/findUserById.test.js
+++ b/server/app/tests/queries/user/findUserById.test.js
@@ -46,4 +46,26 @@ describe('Queries > user > findUserById', () => {
     sinon.assert.called(usersModelStub);
     sinon.assert.called(votesModelStub);
   });
+
+  // With no identifying argument the resolver falls back to "me". It used to
+  // read context.user._id unguarded, so an anonymous caller got a TypeError
+  // surfaced as HTTP 200 + INTERNAL_SERVER_ERROR rather than an auth error.
+  it('rejects an anonymous caller who supplies no identifying argument', async () => {
+    try {
+      await findUserById()(undefined, {}, {});
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect(error.message).to.contain('Authentication required');
+    }
+    sinon.assert.notCalled(usersModelStub);
+  });
+
+  it('still resolves "me" for an authenticated caller', async () => {
+    usersModelStub.resolves(userData);
+    votesModelStub.resolves([]);
+
+    const result = await findUserById()(undefined, {}, { user: { _id: userId } });
+
+    expect(result).is.equal(userData);
+  });
 });

--- a/server/app/tests/utils/requireAuth.test.js
+++ b/server/app/tests/utils/requireAuth.test.js
@@ -1,0 +1,98 @@
+import { expect } from 'chai';
+import requireAuth, { getRootFieldNames } from '~/utils/requireAuth';
+
+describe('utils > requireAuth', () => {
+  describe('public operations', () => {
+    it('allows a public query', () => {
+      expect(requireAuth('query { posts(limit: 5) { entities { _id } } }')).to.equal(false);
+    });
+
+    it('allows public search used by the logged-out landing page', () => {
+      const query = 'query search($text: String!) { posts(searchKey: $text) { entities { _id } } searchUser(queryName: $text) { _id username } }';
+      expect(requireAuth(query)).to.equal(false);
+    });
+
+    it('allows introspection fields', () => {
+      expect(requireAuth('query { __schema { queryType { name } } }')).to.equal(false);
+    });
+  });
+
+  describe('gated operations', () => {
+    it('gates an authenticated query', () => {
+      expect(requireAuth('query { notifications { _id } }')).to.equal(true);
+    });
+
+    it('gates mutations', () => {
+      expect(requireAuth('mutation { addPost(post: {}) { _id } } ')).to.equal(true);
+      expect(requireAuth('mutation { disableUser(userId: "1") { _id } }')).to.equal(true);
+    });
+
+    it('gates when any root field is not public, even alongside a public one', () => {
+      expect(requireAuth('query { posts { entities { _id } } notifications { _id } }')).to.equal(true);
+    });
+  });
+
+  // The whole point of the rewrite: matching used to be String.includes over
+  // the entire document, so mentioning a public name anywhere opened the gate.
+  describe('substring loophole is closed', () => {
+    it('does not treat a nested post selection as public', () => {
+      const query = 'query { notifications { _id post { _id url } } }';
+      expect(requireAuth(query)).to.equal(true);
+    });
+
+    it('does not treat a userId field as making an operation public', () => {
+      expect(requireAuth('query { getRoster { _id userId } }')).to.equal(true);
+    });
+
+    it('does not treat an operation name containing "post" as public', () => {
+      expect(requireAuth('mutation reportPost { reportPost(postId: "1", userId: "2") { _id } }')).to.equal(true);
+    });
+
+    it('does not treat a string argument mentioning a public name as public', () => {
+      expect(requireAuth('query { getBuddyList(filter: "posts") { _id } }')).to.equal(true);
+    });
+  });
+
+  describe('fails closed', () => {
+    it('requires auth for an unparseable document', () => {
+      expect(requireAuth('query { this is not graphql')).to.equal(true);
+    });
+
+    it('requires auth for a missing or non-string query', () => {
+      expect(requireAuth(undefined)).to.equal(true);
+      expect(requireAuth(null)).to.equal(true);
+      expect(requireAuth('')).to.equal(true);
+      expect(requireAuth(42)).to.equal(true);
+    });
+
+    it('requires auth for a document with only fragments and no operation', () => {
+      expect(requireAuth('fragment F on Post { _id }')).to.equal(true);
+    });
+  });
+
+  describe('getRootFieldNames', () => {
+    it('reads root fields from a query', () => {
+      expect(getRootFieldNames('query { posts { _id } user(username: "a") { _id } }'))
+        .to.deep.equal(['posts', 'user']);
+    });
+
+    it('ignores nested fields', () => {
+      expect(getRootFieldNames('query { posts { entities { creator { username } } } }'))
+        .to.deep.equal(['posts']);
+    });
+
+    it('resolves a root fragment spread', () => {
+      const query = 'query { ...Roots } fragment Roots on Query { posts { _id } }';
+      expect(getRootFieldNames(query)).to.deep.equal(['posts']);
+    });
+
+    it('resolves a root inline fragment', () => {
+      expect(getRootFieldNames('query { ... on Query { posts { _id } } }'))
+        .to.deep.equal(['posts']);
+    });
+
+    it('returns null for an unparseable document', () => {
+      expect(getRootFieldNames('{{{')).to.equal(null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`requireAuth` tested `query.includes(publicName)` against the **entire document**, so any operation that merely mentioned `post`, `user`, `group` or `messages` anywhere — a `userId` field, a nested `post { _id }` selection, even a string argument — skipped the gate. In practice almost nothing was gated.

The gate now parses the document and matches **root field names exactly**, resolving fragment spreads and inline fragments at the root, and denying by default.

Addresses **gap 2 of #352**. Gap 1 (magic-link email gateway) is not included — see below.

## Severity: correctness, not an active leak

Sent unauthenticated against production, all of these bypassed the gate and reached their resolvers:

| Operation | Result |
|---|---|
| `users` | `Authentication required to access user data` — resolver guard held |
| `userInviteRequests` | `Authentication required to access invite data` — resolver guard held |
| `getBuddyList`, `getRoster` | `Authentication required` — resolver guard held |
| `messageRooms`, `notifications` | **crashed** on `user._id` → HTTP 200 + `INTERNAL_SERVER_ERROR`, null data |

**No data leaked** — every resolver either guarded or crashed. So this is a robustness fix, not a patch for an active vulnerability. But the gate was providing no protection, resolver guards were the only real defence, and any new resolver written without one is unprotected by default.

## What changed

**Exact root-field matching, fail closed.** An unparseable document, one with no operation, or one containing any non-public root field now requires authentication.

**The allowlist is otherwise unchanged**, so this restores the original intent rather than setting new policy.

**One addition: `searchUser`.** I measured the blast radius before rewriting by running all 77 frontend documents through both the old and new logic. That surfaced `SEARCH`, used by `LandingPageContent.tsx:1561` — and the landing page is **public** (`middleware.ts` only guards `/dashboard` and `/auths`). It passed only through the substring bug. Tightening naively would have broken search for every logged-out visitor.

`searchUser` is safe to serve anonymously: the resolver excludes `hash_password`, reset tokens, `_wallet` and `email`, and caps results at 50.

**Measured outcome across the 77 frontend documents:** 20 remain executable logged out (feed browsing, groups, public search, password reset, invite request), 57 are now gated.

**Logged-in behaviour is unchanged.** The gate only runs for requests with no token at all — when a token is present the context returns early and never consults it.

## Also: a resolver guard

`findUserById` falls back to "me" via `context.user._id` when given no identifying argument. For an anonymous caller that threw a `TypeError`, surfacing as HTTP 200 + `INTERNAL_SERVER_ERROR`. It now returns a clean `AuthenticationError`.

`topPosts` and `getFeaturedPosts` already guarded correctly and were left alone.

## Testing

20 new cases, including the specific loopholes that were open — a nested `post` selection, a `userId` field, an operation *named* `reportPost`, and a string argument containing `"posts"`.

**Mutation-tested** to confirm the suite actually bites:

| Mutation | Result |
|---|---|
| revert to substring matching (the original bug) | 7 failed |
| fail open instead of closed on parse error | 2 failed |
| remove the `findUserById` guard | 1 failed |

- `npm run test --workspace=server` — **42 passing**, 8 suites (up from 22 on `main`)
- `npm run build:server` — compiles 264 files
- No SDL changed, so all 77 frontend documents remain valid by construction
- Lint: 1071 problems vs 1067 on `main`; the +4 are the `~/` alias and `_id` patterns every existing test file already trips

## Not included — gap 1 needs a decision first

The magic-link email gateway is deliberately left out. It hinges on a product decision recorded in #352: **does the gateway reveal whether an email is registered?** quotevote-next#398 requires showing "registered-user state", which is inherently an account-enumeration vector. Accepting it with rate limiting, versus returning uniform responses and signalling only via the emailed link, changes the schema shape — so building first and deciding later means rework.

There is also groundwork underneath it: the existing rate limiter (`utils/rateLimiter.js`) is keyed by `userId` and holds state in memory, so it cannot throttle logged-out callers by email or IP, and will not hold across a pm2 cluster.

## Follow-up worth its own issue

`messages(messageRoomId)` is **anonymously readable** — it is in the original allowlist, so I kept it public rather than silently changing policy in a refactor. Anyone with a valid room ID can read that room's messages without a token:

```bash
curl -s -X POST https://api.quote.vote/graphql -H 'Content-Type: application/json' \
  -d '{"operationName":"getRoomMessages","query":"query getRoomMessages($messageRoomId: String!) { messages(messageRoomId: $messageRoomId) { _id text userId } }","variables":{"messageRoomId":"<room id>"}}'
```

Chat is dashboard-only in the frontend, so gating it is likely safe — but that is a product call, not a refactor decision.
