### PR TITLE
docs: announce the Next.js transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 # Quote Vote
 
+> [!IMPORTANT]
+> **Active development has moved to [QuoteVote/quotevote-next](https://github.com/QuoteVote/quotevote-next).**
+> New frontend work, RC1 bug fixes, and test coverage belong there — not in this repository.
+
 A text-first civic engagement platform for creating posts, voting on specific text passages, and thoughtful discussions. Built with React/GraphQL frontend and Node.js backend, featuring targeted voting, quotes, social features, and moderation tools for transparent public dialogue.
+
+## 📦 Repository status
+
+Quote.Vote is being rebuilt as a Next.js application in [`quotevote-next`](https://github.com/QuoteVote/quotevote-next). That repository is the active development target and is where the production frontend now lives.
+
+**Please open new work there:**
+
+| Work | Where it belongs |
+| --- | --- |
+| RC1 bug fixes | [`quotevote-next`](https://github.com/QuoteVote/quotevote-next/issues) |
+| Frontend features and stabilization | [`quotevote-next`](https://github.com/QuoteVote/quotevote-next) |
+| Playwright end-to-end tests | [`quotevote-next`](https://github.com/QuoteVote/quotevote-next) (`quotevote-frontend/e2e/`) |
+| Unit test coverage | [`quotevote-next`](https://github.com/QuoteVote/quotevote-next) |
+
+### What this repository is still used for
+
+- **`server/` is the live production API.** It serves `api.quote.vote` today, so backend fixes and GraphQL schema changes still land here — until the migrated backend in `quotevote-next/quotevote-backend/` is deployed and takes over.
+- **`client/` is superseded.** The legacy React 17 frontend is kept for historical reference and architecture context. It should not receive new feature work.
+
+**Not sure where something belongs?** Frontend goes to [`quotevote-next`](https://github.com/QuoteVote/quotevote-next); backend and schema changes stay here.
 
 ## 🚀 Features
 
@@ -353,6 +377,9 @@ npm run start:server  # Uses PM2 for production
 
 ## 🤝 Contributing
 
+> [!NOTE]
+> **Before you start:** frontend contributions belong in [`quotevote-next`](https://github.com/QuoteVote/quotevote-next), not here. See [Repository status](#-repository-status). The steps below apply to backend (`server/`) work in this repository.
+
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
 3. Commit your changes (`git commit -m 'Add some amazing feature'`)
@@ -399,15 +426,18 @@ This project is licensed under the LGPL-3.0 license - see the [LICENSE](LICENSE)
 
 ## 🐛 Issues
 
-If you encounter any issues, please:
+**File frontend issues — including RC1 bugs, UI defects, and test gaps — in [`quotevote-next`](https://github.com/QuoteVote/quotevote-next/issues).** Use this repository's tracker only for the production backend in `server/`.
 
-1. Check the existing issues in the repository
+Either way, please:
+
+1. Check the existing issues first
 2. Create a new issue with detailed information
 3. Include steps to reproduce the problem
 
 ## 🔗 Links
 
-- **Repository**: [GitHub Repository]
+- **Active development**: [QuoteVote/quotevote-next](https://github.com/QuoteVote/quotevote-next)
+- **Legacy repository**: [QuoteVote/quotevote-monorepo](https://github.com/QuoteVote/quotevote-monorepo)
 - **Live Demo**: [Demo URL]
 - **Documentation**: [Documentation URL]
 

--- a/README.md
+++ b/README.md
@@ -47,27 +47,30 @@ Quote.Vote is being rebuilt as a Next.js application in [`quotevote-next`](https
 - **Dark/Light Themes**: Customizable user interface themes
 - **Accessibility**: WCAG compliant design with screen reader support
 
-## 🎥 Demo Videos
+## 🎥 Setup Walkthroughs
 
-See Quote Vote in action! Watch our demonstration videos to get a quick overview of the platform's features and functionality:
+Step-by-step videos covering local setup, from cloning the repository to a running application. Pick the one matching your operating system — see [Getting Started](#-getting-started) for the written instructions.
 
-### Windows Demo
+### Windows Setup
 
-Platform demonstration on Windows
+Windows 10, 11 (PowerShell, CMD, Git Bash compatible)
 
-<video src="./docs/videos/mp4/QuoteVote - Windows.mp4" autoplay loop muted playsinline width="600" aria-label="QuoteVote Windows demonstration video"></video>
+<video src="./docs/videos/mp4/QuoteVote - Windows.mp4" autoplay loop muted playsinline width="600" aria-label="QuoteVote Windows setup walkthrough video"></video>
 
-### Linux Demo
+### Linux Setup
 
-Platform demonstration on Linux
+Linux (Arch, Ubuntu, Debian, Fedora compatible)
 
-<video src="./docs/videos/mp4/QuoteVote - linux.mp4" autoplay loop muted playsinline width="600" aria-label="QuoteVote Linux demonstration video"></video>
+<video src="./docs/videos/mp4/QuoteVote - linux.mp4" autoplay loop muted playsinline width="600" aria-label="QuoteVote Linux setup walkthrough video"></video>
 
-**These videos showcase:**
-- Creating and voting on posts
-- Highlighting and discussing quotes
-- Using the moderation tools
-- Navigating the user interface
+**Each walkthrough covers:**
+- Initial project setup using `setup.js`
+- Creating admin and developer accounts
+- Starting the development servers with `start.js`
+- Navigating the running application
+- Common workflows and platform-specific tips
+
+More detail on the setup scripts themselves is in [`scripts/README.md`](./scripts/README.md).
 
 ## 🛠 Tech Stack
 


### PR DESCRIPTION
## Summary

New contributors had no way to tell that development energy has moved to [`quotevote-next`](https://github.com/QuoteVote/quotevote-next). This adds a status notice at the top of the README and makes the guidance consistent through the Contributing, Issues and Links sections.

Implements QuoteVote/quotevote-next#385.

## Changes

**A status notice under the title** — an `[!IMPORTANT]` callout pointing at `quotevote-next`, so it is the first thing anyone sees.

**A "Repository status" section** routing the four work types the issue names:

| Work | Where it belongs |
| --- | --- |
| RC1 bug fixes | `quotevote-next` |
| Frontend features and stabilization | `quotevote-next` |
| Playwright end-to-end tests | `quotevote-next` (`quotevote-frontend/e2e/`) |
| Unit test coverage | `quotevote-next` |

**Consistent guidance elsewhere**, so the notice is not stranded at the top:

- **Contributing** opens with a note that frontend work belongs in `quotevote-next`; the steps that follow apply to `server/`
- **Issues** says which tracker to use for what
- **Links** replaces the `[GitHub Repository]` placeholder with the active and legacy repositories

## One deliberate deviation — please review

The issue frames the whole monorepo as "no longer actively supported for new feature development". **I did not word it that way, because it is not true of `server/`.**

That directory is the live production GraphQL API behind `api.quote.vote`, it is deployed from this repository, and it is actively taking fixes — PRs #353, #354, #356 and #357 are all open against it right now. A blanket "not supported, go to quotevote-next" notice would send backend contributors to a repository whose backend is **not deployed**, which is the opposite of the intent.

So the notice splits the two:

- **`client/` is superseded** — kept for historical reference and architecture context, no new feature work
- **`server/` still receives backend and schema work** — until the migrated backend in `quotevote-next/quotevote-backend/` is deployed and takes over

and closes with a one-line rule: *frontend goes to `quotevote-next`; backend and schema changes stay here.*

This still meets every acceptance criterion in #385 — a clear status notice near the top, contributors directed to the correct codebase, no ambiguity about where fixes and tests belong, and the legacy repo framed as reference material. It just draws the line where the deployment actually sits. Happy to simplify to the issue's literal wording if you would rather.

## Second commit: the videos were mislabelled

Separate from #385, and worth its own look.

The README billed the two videos as a product tour — *"See Quote Vote in action"*, showcasing voting, quotes and moderation tools. They are actually **per-OS setup walkthroughs**, clone through to a running application. That is why there is a Windows one and a Linux one; you do not need per-OS videos to demo features.

`scripts/README.md` already described them correctly ("QuoteVote - Windows **Setup**", aria-label "setup demonstration video"), so this aligns the top-level README with it and links the two together:

- retitled to **Setup Walkthroughs**, with **Windows Setup** / **Linux Setup** subsections
- the feature list is replaced with what the videos actually cover, taken from `scripts/README.md` — `setup.js`, admin and developer accounts, `start.js`, navigating the running app, platform tips
- notes the OS versions each targets
- points to Getting Started for the written instructions and to `scripts/README.md` for script detail
- corrects the aria-labels

## Verification

- All three GitHub links return HTTP 200
- Both referenced paths exist (`quotevote-frontend/e2e/`, `quotevote-backend/`)
- Anchor targets resolve (`#-repository-status`, `#-getting-started`), as does the relative link to `scripts/README.md`
- Documentation only — no code, no schema, no build impact

## Known nit, left alone

The Setup Walkthroughs section still sits between **Features** and **Tech Stack**, which is an odd home for setup content — it would read better beside **Getting Started**. Moving it is a structural change beyond the scope of this PR; happy to do it if wanted.
