### PR TITLE
fix(profile): restore user reputation with background refresh

### DIFF
--- a/server/app/data/resolvers/index.js
+++ b/server/app/data/resolvers/index.js
@@ -34,11 +34,11 @@ const resolvers = {
   Roster: relationship.rosterRelationship(),
   TypingIndicator: relationship.typingIndicatorRelationship(),
 
-  // user_relationship was never added to this map, so its field resolvers have
-  // never run — User.reputation returns null in production today. Only
-  // `presence` is wired here: enabling `reputation` would start running
-  // ReputationCalculator on every user query, which needs its own review.
-  User: { presence: relationship.user_relationship.User.presence },
+  // User field resolvers are registered explicitly so nullable relationship
+  // fields cannot silently return null when their module is exported.
+  User: {
+    presence: relationship.user_relationship.User.presence,
+    reputation: relationship.user_relationship.User.reputation,
+  },
 };
-
 export { resolvers };

--- a/server/app/data/resolvers/relationship/user_relationship.js
+++ b/server/app/data/resolvers/relationship/user_relationship.js
@@ -1,6 +1,5 @@
 import UserReputationModel from '../models/UserReputationModel';
 import PresenceModel from '../models/PresenceModel';
-import ReputationCalculator from '../utils/reputationCalculator';
 import { logger } from '../../utils/logger';
 
 export const user_relationship = {
@@ -18,28 +17,17 @@ export const user_relationship = {
         return null;
       }
     },
-    reputation: async (parent) => {
-      try {
-        // Get existing reputation or calculate new one
-        let reputation = await UserReputationModel.findOne({ _userId: parent._id });
-        
-        // If no reputation exists or it's been more than 24 hours since last calculation, recalculate
-        const shouldRecalculate = !reputation || 
-          (Date.now() - new Date(reputation.lastCalculated).getTime()) > (24 * 60 * 60 * 1000);
-        
-        if (shouldRecalculate) {
-          reputation = await ReputationCalculator.calculateUserReputation(parent._id);
-        }
-        
-        return reputation;
-      } catch (error) {
-        logger.error('Error getting user reputation in relationship', {
-          error: error.message,
-          stack: error.stack,
-          userId: parent._id,
-        });
-        return null;
-      }
-    },
+      reputation: async (parent) => {
+    try {
+      return await UserReputationModel.findOne({ _userId: parent._id });
+    } catch (error) {
+      logger.error('Error getting user reputation in relationship', {
+        error: error.message,
+        stack: error.stack,
+        userId: parent._id,
+      });
+      return null;
+    }
+  },
   },
 };

--- a/server/app/data/utils/reputation/refreshReputations.js
+++ b/server/app/data/utils/reputation/refreshReputations.js
@@ -1,0 +1,48 @@
+import reputationCalculator from '../../resolvers/utils/reputationCalculator';
+import { logger } from '../logger';
+
+export const REPUTATION_REFRESH_INTERVAL = 24 * 60 * 60 * 1000;
+
+let refreshInProgress = false;
+
+export const refreshReputations = async () => {
+  if (refreshInProgress) {
+    logger.warn('[Reputation Refresh] Skipping overlapping refresh');
+    return;
+  }
+
+  refreshInProgress = true;
+
+  try {
+    const results = await reputationCalculator.recalculateAllReputations();
+    const successful = results.filter((result) => result.success).length;
+    const failed = results.length - successful;
+
+    logger.info('[Reputation Refresh] Completed', {
+      total: results.length,
+      successful,
+      failed,
+    });
+  } catch (error) {
+    logger.error('[Reputation Refresh] Failed', {
+      error: error.message,
+      stack: error.stack,
+    });
+  } finally {
+    refreshInProgress = false;
+  }
+};
+
+export const startReputationRefresh = () => {
+  const interval = setInterval(refreshReputations, REPUTATION_REFRESH_INTERVAL);
+
+  refreshReputations();
+  logger.info('[Reputation Refresh] Started background refresh job');
+
+  return interval;
+};
+
+export default {
+  refreshReputations,
+  startReputationRefresh,
+};

--- a/server/app/server.js
+++ b/server/app/server.js
@@ -20,6 +20,7 @@ import {
 import { schema } from './data/schema';
 import requireAuth from '~/utils/requireAuth';
 import { startPresenceCleanup } from './data/utils/presence/cleanupStalePresence';
+import { startReputationRefresh } from './data/utils/reputation/refreshReputations';
 import PostModel from './data/resolvers/models/PostModel';
 import UserModel from './data/resolvers/models/UserModel';
 
@@ -304,6 +305,7 @@ async function startServer() {
     logger.info(`WebSocket server ready at ws://localhost:${GRAPHQL_PORT}/graphql`);
     // Start presence cleanup job
     startPresenceCleanup();
+    startReputationRefresh();
   });
 }
 

--- a/server/app/tests/resolvers/userReputationWiring.test.js
+++ b/server/app/tests/resolvers/userReputationWiring.test.js
@@ -1,0 +1,59 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import UserReputationModel from '../../data/resolvers/models/UserReputationModel';
+import ReputationCalculator from '../../data/resolvers/utils/reputationCalculator';
+
+jest.mock('../../data/resolvers/subscriptions', () => ({
+  pubsub: { publish: jest.fn().mockResolvedValue(undefined) },
+  Subscription: {},
+}));
+
+import { resolvers } from '../../data/resolvers';
+
+/**
+ * Regression guard: User.reputation must be registered in the resolver map.
+ * It must also read the stored reputation only; recalculation belongs to the
+ * background refresh job, never a profile or user-list query.
+ */
+describe('resolvers > User reputation field resolver', () => {
+  it('exposes User.reputation in the resolver map', () => {
+    expect(resolvers.User).to.be.an('object');
+    expect(resolvers.User.reputation).to.be.a('function');
+  });
+
+  describe('User.reputation', () => {
+    let findOneStub;
+    let calculateStub;
+
+    beforeEach(() => {
+      findOneStub = sinon.stub(UserReputationModel, 'findOne');
+      calculateStub = sinon.stub(ReputationCalculator, 'calculateUserReputation');
+    });
+
+    afterEach(() => {
+      findOneStub.restore();
+      calculateStub.restore();
+    });
+
+    it('reads the stored reputation without recalculating it', async () => {
+      const reputation = {
+        _userId: 'user-1',
+        overallScore: 124,
+        lastCalculated: new Date(0),
+      };
+      findOneStub.resolves(reputation);
+
+      const result = await resolvers.User.reputation({ _id: 'user-1' });
+
+      expect(result).to.equal(reputation);
+      sinon.assert.calledWith(findOneStub, { _userId: 'user-1' });
+      sinon.assert.notCalled(calculateStub);
+    });
+
+    it('returns null instead of throwing when the lookup fails', async () => {
+      findOneStub.rejects(new Error('mongo is down'));
+
+      expect(await resolvers.User.reputation({ _id: 'user-1' })).to.equal(null);
+    });
+  });
+});

--- a/server/app/tests/utils/reputationRefresh.test.js
+++ b/server/app/tests/utils/reputationRefresh.test.js
@@ -1,0 +1,56 @@
+jest.mock('../../data/resolvers/utils/reputationCalculator', () => ({
+  __esModule: true,
+  default: {
+    recalculateAllReputations: jest.fn(),
+  },
+}));
+
+jest.mock('../../data/utils/logger', () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+import ReputationCalculator from '../../data/resolvers/utils/reputationCalculator';
+import { logger } from '../../data/utils/logger';
+import {
+  REPUTATION_REFRESH_INTERVAL,
+  refreshReputations,
+} from '../../data/utils/reputation/refreshReputations';
+
+describe('reputation refresh job', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('recalculates all reputations outside a request', async () => {
+    ReputationCalculator.recalculateAllReputations.mockResolvedValue([
+      { success: true },
+      { success: false },
+    ]);
+
+    await refreshReputations();
+
+    expect(ReputationCalculator.recalculateAllReputations).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('[Reputation Refresh] Completed', {
+      total: 2,
+      successful: 1,
+      failed: 1,
+    });
+  });
+
+  it('logs an error instead of throwing when refresh fails', async () => {
+    ReputationCalculator.recalculateAllReputations.mockRejectedValue(
+      new Error('database unavailable'),
+    );
+
+    await expect(refreshReputations()).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('uses a 24-hour refresh interval', () => {
+    expect(REPUTATION_REFRESH_INTERVAL).toBe(24 * 60 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
## Summary

- register `User.reputation` in the central GraphQL resolver map
- serve the stored reputation record on profile/user reads, without inline recalculation
- add a guarded 24-hour background refresh started with the server
- add regression tests for resolver wiring and refresh behavior

Fixes #355

## Validation

- `npm test -- --runInBand` — 20 suites / 110 tests passed
- `npm run build` — passed
- targeted background refresh module lint — passed

## Note

`npm run unittest` is blocked before test execution by the existing `Subscription` resolver bootstrap error (`Subscription` is `undefined`), outside this change.